### PR TITLE
Implement Replicate image generation

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -836,6 +836,9 @@ OPENAI_API_BASE_URL = os.environ.get("OPENAI_API_BASE_URL", "")
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
 GEMINI_API_BASE_URL = os.environ.get("GEMINI_API_BASE_URL", "")
 
+REPLICATE_API_KEY = os.environ.get("REPLICATE_API_KEY", "")
+REPLICATE_API_BASE_URL = os.environ.get("REPLICATE_API_BASE_URL", "https://api.replicate.com")
+
 
 if OPENAI_API_BASE_URL == "":
     OPENAI_API_BASE_URL = "https://api.openai.com/v1"
@@ -2734,6 +2737,7 @@ IMAGES_GEMINI_API_KEY = PersistentConfig(
     os.getenv("IMAGES_GEMINI_API_KEY", GEMINI_API_KEY),
 )
 
+
 IMAGE_SIZE = PersistentConfig(
     "IMAGE_SIZE", "image_generation.size", os.getenv("IMAGE_SIZE", "512x512")
 )
@@ -2747,6 +2751,7 @@ IMAGE_GENERATION_MODEL = PersistentConfig(
     "image_generation.model",
     os.getenv("IMAGE_GENERATION_MODEL", ""),
 )
+
 
 ####################################
 # Audio

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1070,7 +1070,7 @@ app.mount("/ws", socket_app)
 app.include_router(ollama.router, prefix="/ollama", tags=["ollama"])
 app.include_router(openai.router, prefix="/openai", tags=["openai"])
 
-app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"])
+app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"]) 
 app.include_router(tasks.router, prefix="/api/v1/tasks", tags=["tasks"])
 app.include_router(images.router, prefix="/api/v1/images", tags=["images"])
 

--- a/backend/open_webui/model_configs.py
+++ b/backend/open_webui/model_configs.py
@@ -1,0 +1,7 @@
+import os
+
+MODEL_CONFIGS = {
+    "ideogram-ai/ideogram-v3-turbo": os.getenv("IDEOGRAM_V3_TURBO_VERSION", ""),
+    "runwayml/gen4-image": os.getenv("RUNWAYML_GEN4_IMAGE_VERSION", ""),
+    "openai/gpt-image-1": os.getenv("GPT_IMAGE_1_VERSION", ""),
+}

--- a/backend/open_webui/models/billing.py
+++ b/backend/open_webui/models/billing.py
@@ -78,9 +78,9 @@ class CreditTransaction(Base):
     usd_spend = Column(Numeric, nullable=False)
     model_name = Column(Text, nullable=False)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
-    # resource_type = Column(String(32), nullable=True)
-    # reference_id  = Column(String)         # FK to image_jobs.id (optional)
-    # meta = Column(JSON, nullable=True)
+    resource_type = Column(String(32), nullable=True)
+    reference_id = Column(String)
+    meta = Column(JSON, nullable=True)
 
 
 class PaymentOrder(Base):
@@ -177,6 +177,9 @@ class CreditTransactionModel(BaseModel):
     delta: int
     usd_spend: float
     model_name: str
+    resource_type: Optional[str] = None
+    reference_id: Optional[str] = None
+    meta: Optional[dict] = None
     created_at: int
 
 
@@ -185,6 +188,9 @@ class CreditTransactionForm(BaseModel):
     delta: int
     usd_spend: float
     model_name: str
+    resource_type: Optional[str] = None
+    reference_id: Optional[str] = None
+    meta: Optional[dict] = None
 
 
 class PaymentOrderModel(BaseModel):
@@ -336,6 +342,9 @@ class CreditTransactionsTable:
                 delta=form.delta,
                 usd_spend=form.usd_spend,
                 model_name=form.model_name,
+                resource_type=form.resource_type,
+                reference_id=form.reference_id,
+                meta=form.meta,
                 created_at=now_ts,
             )
             db.add(record)

--- a/backend/open_webui/models/image_jobs.py
+++ b/backend/open_webui/models/image_jobs.py
@@ -1,9 +1,11 @@
 import enum
 import time
+import logging
 from typing import Optional, Literal
 import uuid
 
 from open_webui.internal.db import Base, get_db
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
     Column,
@@ -12,8 +14,13 @@ from sqlalchemy import (
     BigInteger,
     Integer,
     Float,
-    Enum as SAEnum, ForeignKey
+    Enum as SAEnum,
+    ForeignKey,
+    JSON,
 )
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["MODELS"])
 
 # Status enum for ImageJob
 class JobStatusEnum(enum.Enum):
@@ -37,6 +44,7 @@ class ImageJob(Base):
     predict_time = Column(Float)
     usd_cost = Column(Float)
     credits_spent = Column(Integer)
+    meta = Column(JSON)
     attempts = Column(Integer, default=0)
     created_at = Column(BigInteger, default=lambda: int(time.time()))
     completed_at = Column(BigInteger)
@@ -56,6 +64,7 @@ class ImageJobModel(BaseModel):
     predict_time: Optional[float] = None
     usd_cost: Optional[float] = None
     credits_spent: Optional[int] = None
+    meta: Optional[dict] = None
     attempts: int
     created_at: int
     completed_at: Optional[int] = None
@@ -72,6 +81,7 @@ class ImageJobsTable:
         model_name: str,
         negative_prompt: Optional[str] = None,
     ) -> ImageJobModel:
+        log.info(f"Inserting new image job for user {user_id}")
         with get_db() as db:
             job = ImageJob(
                 user_id=user_id,
@@ -82,7 +92,41 @@ class ImageJobsTable:
             db.add(job)
             db.commit()
             db.refresh(job)
+            log.debug(f"Inserted job {job.id}")
             return ImageJobModel.model_validate(job)
+
+    def get_image_job_by_job_id(self, job_id: str) -> Optional[ImageJobModel]:
+        try:
+            with get_db() as db:
+                job = db.query(ImageJob).filter_by(id=job_id).first()
+                if job:
+                    log.debug(f"Fetched job {job_id}")
+                    return ImageJobModel.model_validate(job)
+                log.debug(f"Job {job_id} not found")
+                return None
+        except Exception as e:
+            log.error(f"Error fetching job {job_id}: {e}")
+            return None
+
+    def update_image_job_by_id(self, job_id: str, updates: dict) -> Optional[ImageJobModel]:
+        """Update an ImageJob and return the updated model."""
+        try:
+            with get_db() as db:
+                job = db.query(ImageJob).filter_by(id=job_id).first()
+                if not job:
+                    log.warning(f"Attempted to update missing job {job_id}")
+                    return None
+
+                for key, value in updates.items():
+                    setattr(job, key, value)
+
+                db.commit()
+                db.refresh(job)
+                log.debug(f"Updated job {job_id} with {updates}")
+                return ImageJobModel.model_validate(job)
+        except Exception as e:
+            log.error(f"Error updating job {job_id}: {e}")
+            return None
 
 
 ImageJobs = ImageJobsTable()

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -9,12 +9,22 @@ from pathlib import Path
 from typing import Optional
 
 import requests
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
 from open_webui.routers.files import upload_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.models.image_jobs import ImageJobs, JobStatusEnum
+from open_webui.utils.images.input_builders import build_model_input
+from open_webui.utils.images.image_tasks import enqueue_prediction_job
+from open_webui.models.users import Users
+from open_webui.models.billing import CreditTransactions, CreditTransactionForm, UserCredits
+from open_webui.model_configs import MODEL_CONFIGS
+from open_webui.telegram_bot import send_telegram_message
+from open_webui.config import REPLICATE_API_BASE_URL
+import uuid
+import time
 from open_webui.utils.images.comfyui import (
     ComfyUIGenerateImageForm,
     ComfyUIWorkflow,
@@ -679,3 +689,127 @@ async def image_generations(
             if "error" in data:
                 error = data["error"]["message"]
         raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(error))
+
+
+@router.post("/predictions")
+async def create_prediction(
+    request: Request,
+    payload: str = Form(...),
+    style_reference_images: list[UploadFile] | None = File(None),
+    reference_images: list[UploadFile] | None = File(None),
+    image: UploadFile | None = File(None),
+    user=Depends(get_verified_user),
+):
+    log.info(f"Creating prediction for user {user.id}")
+    try:
+        payload_data = json.loads(payload)
+    except json.JSONDecodeError:
+        log.error("Invalid payload JSON")
+        raise HTTPException(status_code=400, detail="Invalid payload JSON")
+
+    file_urls: dict[str, list[str] | str] = {}
+    if style_reference_images:
+        urls = []
+        for f in style_reference_images:
+            data = await f.read()
+            url = upload_image(request, data, f.content_type or "image/png", {}, user)
+            urls.append(url)
+        file_urls["style_reference_images"] = urls
+        log.debug("Uploaded style reference images")
+    if reference_images:
+        urls = []
+        for f in reference_images:
+            data = await f.read()
+            url = upload_image(request, data, f.content_type or "image/png", {}, user)
+            urls.append(url)
+        file_urls["reference_images"] = urls
+        log.debug("Uploaded reference images")
+    if image:
+        data = await image.read()
+        file_urls["image"] = upload_image(request, data, image.content_type or "image/png", {}, user)
+        log.debug("Uploaded inpainting image")
+
+    model_slug = payload_data.get("model")
+    if not model_slug:
+        log.error("Model slug missing in payload")
+        raise HTTPException(status_code=400, detail="model is required")
+
+    built_input = build_model_input(model_slug, json.dumps(payload_data), file_urls)
+    
+    job = ImageJobs.insert_new_job(
+        user.id,
+        prompt=payload_data.get("prompt", ""),
+        model_name=model_slug,
+        negative_prompt=payload_data.get("negative_prompt"),
+    )
+    log.info(f"Enqueued image job {job.id} for model {model_slug}")
+    enqueue_prediction_job(job.id, built_input, user)
+    return {"job_id": job.id, "status": job.status.value}
+
+
+@router.post("/webhook/{job_id}")
+async def prediction_webhook(request: Request, job_id: str, data: dict):
+    log.info(f"Webhook received for job {job_id}")
+    predict_time = data.get("predict_time", 0.0)
+    output = data.get("output")
+    replicate_id = data.get("id")
+
+    job = ImageJobs.get_image_job_by_job_id(job_id)
+    if not job:
+        log.error(f"Job {job_id} not found for webhook")
+        raise HTTPException(status_code=404, detail="Job not found")
+    ImageJobs.update_image_job_by_id(job_id, {"replicate_id": replicate_id})
+    model_slug = job.model_name
+    version = MODEL_CONFIGS.get(model_slug)
+
+    owner, model = model_slug.split("/", 1)
+    price_resp = requests.get(
+        f"{REPLICATE_API_BASE_URL}/v1/models/{owner}/{model}/versions/{version}"
+    )
+    log.debug(f"Pricing response: {price_resp.text}")
+    usd_per_second = (
+        price_resp.json().get("pricing", {}).get("predict_time", {}).get("usd_per_second", 0.0)
+    )
+    usd_cost = float(predict_time) * float(usd_per_second)
+    credits = int(usd_cost / 0.0015)
+
+    image_url = output[0] if isinstance(output, list) else output
+    img_data = requests.get(image_url).content if image_url else b""
+    user = Users.get_user_by_id(job.user_id)
+    saved_url = upload_image(request, img_data, "image/png", {}, user)
+
+    ImageJobs.update_image_job_by_id(
+        job_id,
+        {
+            "output_url": saved_url,
+            "status": JobStatusEnum.succeeded,
+            "predict_time": predict_time,
+            "usd_cost": usd_cost,
+            "credits_spent": credits,
+            "completed_at": int(time.time()),
+            "meta": data,
+        },
+    )
+
+    CreditTransactions.insert_transaction(
+        job.user_id,
+        CreditTransactionForm(
+            tx_id=str(uuid.uuid4()),
+            delta=-credits,
+            usd_spend=usd_cost,
+            model_name=job.model_name,
+            resource_type="image",
+            reference_id=job.id,
+            meta=data,
+        ),
+    )
+    credits_record = UserCredits.update_credits(job.user_id, -credits)
+    if credits_record and credits_record.credit_balance <= 0 and user and user.telegram_chat_id:
+        await send_telegram_message(
+            user.telegram_chat_id,
+            "⚠️ You've reached your credit limit. Upgrade your plan to keep creating great images!",
+        )
+    log.info(
+        f"Job {job_id} completed. Cost: ${usd_cost:.4f}, credits spent: {credits}"
+    )
+    return {"detail": "ok"}

--- a/backend/open_webui/utils/images/image_tasks.py
+++ b/backend/open_webui/utils/images/image_tasks.py
@@ -1,0 +1,40 @@
+import logging
+from redis import Redis
+from rq import Queue
+
+from open_webui.env import REDIS_URL, SRC_LOG_LEVELS
+from open_webui.workers.image_worker import run_prediction
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["IMAGES"])
+
+redis_conn = Redis.from_url(REDIS_URL)
+standard_queue = Queue("image_standard", connection=redis_conn)
+hires_queue = Queue("image_hires", connection=redis_conn)
+
+HIRES_MODELS = {"runwayml/gen4-image", "openai/gpt-image-1"}
+
+
+def route_image_job(user, input: dict) -> str:
+    """Return the queue name for the given job input."""
+    if input.get("resolution") in ["4K", "2048x2048"]:
+        log.debug("Routing to hires queue due to resolution")
+        return "hires"
+    if input.get("model") in HIRES_MODELS:
+        log.debug("Routing to hires queue due to model")
+        return "hires"
+    log.debug("Routing to standard queue")
+    return "standard"
+
+def enqueue_prediction_job(job_id: str, payload: dict, user=None) -> str:
+    """Enqueue a prediction job and return the RQ job id."""
+    try:
+        queue_name = route_image_job(user, payload)
+        log.info(f"Enqueuing job {job_id} on {queue_name} queue")
+        q = hires_queue if queue_name == "hires" else standard_queue
+        rq_job = q.enqueue(run_prediction, job_id, payload)
+        log.debug(f"RQ job {rq_job.id} created for {job_id}")
+        return rq_job.id
+    except Exception as e:
+        log.error(f"Failed to enqueue job {job_id}: {e}")
+        raise

--- a/backend/open_webui/utils/images/input_builders.py
+++ b/backend/open_webui/utils/images/input_builders.py
@@ -1,0 +1,30 @@
+import json
+import logging
+
+from open_webui.env import SRC_LOG_LEVELS
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["IMAGES"])
+
+
+def build_model_input(model_slug: str, payload_json: str, file_urls: dict) -> dict:
+    log.debug(f"Building model input for {model_slug}")
+    payload = json.loads(payload_json) if payload_json else {}
+    if model_slug == "ideogram-ai/ideogram-v3-turbo":
+        if "style_reference_images" in file_urls:
+            log.debug("Adding style_reference_images to payload")
+            payload["style_reference_images"] = file_urls["style_reference_images"]
+    elif model_slug == "runwayml/gen4-image":
+        if "reference_images" in file_urls:
+            log.debug("Adding reference_images to payload")
+            payload["reference_images"] = file_urls["reference_images"]
+    elif model_slug == "openai/gpt-image-1":
+        if "image" in file_urls:
+            log.debug("Adding image to payload")
+            payload["image"] = file_urls["image"]
+    else:
+        payload.update(file_urls)
+        if file_urls:
+            log.debug("Added generic file URLs to payload")
+    log.debug(f"Final built input: {payload}")
+    return payload

--- a/backend/open_webui/workers/image_worker.py
+++ b/backend/open_webui/workers/image_worker.py
@@ -1,0 +1,66 @@
+import logging
+import time
+import requests
+import replicate
+
+from open_webui.internal.db import get_db
+from open_webui.models.image_jobs import ImageJob, JobStatusEnum
+from open_webui.models.billing import CreditTransactions, CreditTransactionForm, UserCredits
+from open_webui.models.users import Users
+from open_webui.config import WEBUI_URL, REPLICATE_API_BASE_URL, REPLICATE_API_KEY
+from open_webui.model_configs import MODEL_CONFIGS
+from open_webui.env import SRC_LOG_LEVELS
+
+from sqlalchemy.orm import Session
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["IMAGES"])
+
+
+def run_prediction(job_id: str, payload: dict) -> None:
+    log.info(f"Running prediction for job {job_id}")
+    with get_db() as db:
+        job: ImageJob | None = db.query(ImageJob).filter(ImageJob.id == job_id).first()
+        if not job:
+            log.error(f"Job {job_id} not found")
+            return
+        job.status = JobStatusEnum.running
+        db.commit()
+        db.refresh(job)
+        log.debug(f"Job {job_id} marked as running")
+
+    model_slug = job.model_name
+    version = MODEL_CONFIGS.get(model_slug)
+    if not version:
+        log.error(f"No version configured for {model_slug}")
+        with get_db() as db:
+            db.query(ImageJob).filter_by(id=job_id).update({"status": JobStatusEnum.failed})
+            db.commit()
+        return
+
+    webhook_url = f"{WEBUI_URL}/api/v1/images/webhook/{job_id}"
+    try:
+        client = replicate.Client(api_token=REPLICATE_API_KEY, base_url=REPLICATE_API_BASE_URL)
+        prediction = client.predictions.create(
+            version=version,
+            input=payload,
+            webhook=webhook_url,
+            webhook_events_filter=["completed"],
+        )
+        with get_db() as db:
+            db.query(ImageJob).filter_by(id=job_id).update({
+                "replicate_id": prediction.id,
+                "meta": prediction.__dict__,
+            })
+            db.commit()
+        log.info(f"Prediction started for job {job_id}: {prediction.id}")
+    except Exception as e:
+        log.error(f"Prediction failed to start for job {job_id}: {e}")
+        with get_db() as db:
+            db.query(ImageJob).filter_by(id=job_id).update({
+                "status": JobStatusEnum.failed,
+                "meta": {"error": str(e)},
+            })
+            db.commit()
+        return
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,6 +27,8 @@ bcrypt==4.3.0
 
 pymongo
 redis
+rq
+replicate
 boto3==1.35.53
 
 argon2-cffi==23.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
 
     "pymongo",
     "redis",
+    "rq",
+    "replicate",
     "boto3==1.35.53",
 
     "argon2-cffi==23.1.0",


### PR DESCRIPTION
## Summary
- add meta column to image jobs for storing Replicate responses
- support extra metadata in credit transaction model
- expose `REPLICATE_API_BASE_URL` configuration
- encapsulate job DB access via helper methods
- improve webhook handling and Telegram messaging
- route image jobs to separate queues and move worker into dedicated folder
- refactor image job update to align with other data models
- add detailed logging for the image generation process
- move image task utilities into `utils/images` module
- add configuration for Replicate API key and use it in `image_worker`
- remove duplicate Replicate configuration definitions

## Testing
- `python -m py_compile backend/open_webui/config.py backend/open_webui/workers/image_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_688a1d840c1483339087b5898a921651