### PR TITLE
Add affiliate tracking endpoints and attribution service

### DIFF
--- a/backend/open_webui/core/affiliate/__init__.py
+++ b/backend/open_webui/core/affiliate/__init__.py
@@ -1,0 +1,3 @@
+from .attribution import resolve_attribution_on_auth, choose_final_attribution
+
+__all__ = ["resolve_attribution_on_auth", "choose_final_attribution"]

--- a/backend/open_webui/core/affiliate/attribution.py
+++ b/backend/open_webui/core/affiliate/attribution.py
@@ -1,0 +1,43 @@
+import datetime
+import hashlib
+from typing import Optional
+
+from fastapi import Request, Response
+
+from open_webui.env import WEBUI_AUTH_COOKIE_SAME_SITE, WEBUI_AUTH_COOKIE_SECURE
+from open_webui.models.affiliate import Attribution
+
+
+def resolve_attribution_on_auth(email: str, request: Request, response: Response) -> None:
+    """On authentication, renew attribution-related cookies and store email hash."""
+    email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
+    expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+
+    attr_id = request.cookies.get("aff_attr_id")
+    if attr_id:
+        response.set_cookie(
+            key="aff_attr_id",
+            value=attr_id,
+            expires=expires,
+            httponly=True,
+            samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+            secure=WEBUI_AUTH_COOKIE_SECURE,
+        )
+
+    response.set_cookie(
+        key="aff_email_hash",
+        value=email_hash,
+        expires=expires,
+        httponly=True,
+        samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+        secure=WEBUI_AUTH_COOKIE_SECURE,
+    )
+
+
+def choose_final_attribution(
+    coupon: Optional[Attribution] = None,
+    last_click: Optional[Attribution] = None,
+    manual: Optional[Attribution] = None,
+) -> Optional[Attribution]:
+    """Determine final attribution priority: coupon > last-click > manual."""
+    return coupon or last_click or manual

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -84,6 +84,7 @@ from open_webui.routers import (
     plans,
     quota_policy # Added quota_policy router
 )
+from open_webui.routers.affiliate import tracking as affiliate_tracking
 
 from open_webui.routers.retrieval import (
     get_embedding_function,
@@ -1105,6 +1106,7 @@ app.include_router(storage.router, prefix="/api/v1/storage", tags=["storage"])
 app.include_router(discount.router, prefix="/api/v1/discount", tags=["discount"])
 app.include_router(plans.router, prefix="/api/v1/plans", tags=["plans"])
 app.include_router(quota_policy.router, prefix="/api/v1/quota_policies", tags=["quota_policies"]) # Added quota_policy router
+app.include_router(affiliate_tracking.router, prefix="/t/affiliate", tags=["affiliate"])
 
 try:
     audit_level = AuditLevel(AUDIT_LOG_LEVEL)

--- a/backend/open_webui/routers/affiliate/__init__.py
+++ b/backend/open_webui/routers/affiliate/__init__.py
@@ -1,0 +1,3 @@
+from . import tracking
+
+__all__ = ["tracking"]

--- a/backend/open_webui/routers/affiliate/tracking.py
+++ b/backend/open_webui/routers/affiliate/tracking.py
@@ -1,0 +1,130 @@
+import datetime
+import hashlib
+
+from fastapi import APIRouter, Request, Response, HTTPException
+from pydantic import BaseModel
+
+from open_webui.env import WEBUI_AUTH_COOKIE_SAME_SITE, WEBUI_AUTH_COOKIE_SECURE
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Click, Attribution, AttrViaEnum
+
+router = APIRouter()
+
+
+class ClickForm(BaseModel):
+    partner_id: str
+    link_id: str | None = None
+    coupon_id: str | None = None
+
+
+@router.post("/click")
+async def track_click(form: ClickForm, request: Request, response: Response):
+    """Track an affiliate click and set identification cookies."""
+    user_agent = request.headers.get("User-Agent", "")
+    dedupe_hash = hashlib.sha256(
+        f"{form.partner_id}:{form.link_id or ''}:{form.coupon_id or ''}:{user_agent}".encode()
+    ).hexdigest()
+
+    # If the dedupe hash matches the cookie, avoid duplicate insert
+    if request.cookies.get("aff_click_hash") == dedupe_hash:
+        existing_id = request.cookies.get("aff_click_id")
+        if existing_id:
+            return {"click_id": existing_id}
+
+    with get_db() as db:
+        record = Click(
+            partner_id=form.partner_id,
+            link_id=form.link_id,
+            coupon_id=form.coupon_id,
+            user_agent=user_agent,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+
+    expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+    response.set_cookie(
+        key="aff_click_id",
+        value=str(record.id),
+        expires=expires,
+        httponly=True,
+        samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+        secure=WEBUI_AUTH_COOKIE_SECURE,
+    )
+    response.set_cookie(
+        key="aff_click_hash",
+        value=dedupe_hash,
+        expires=expires,
+        httponly=True,
+        samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+        secure=WEBUI_AUTH_COOKIE_SECURE,
+    )
+
+    return {"click_id": record.id}
+
+
+class AttributionForm(BaseModel):
+    partner_id: str
+    attr_via: AttrViaEnum
+    click_id: int | None = None
+    email: str | None = None
+
+
+@router.post("/attribution")
+async def create_attribution(
+    form: AttributionForm, request: Request, response: Response
+):
+    """Create an attribution record based on a tracked click."""
+    click_id = form.click_id or request.cookies.get("aff_click_id")
+    if not click_id:
+        raise HTTPException(status_code=400, detail="click_id missing")
+
+    email_hash = None
+    if form.email:
+        email_hash = hashlib.sha256(form.email.lower().encode()).hexdigest()
+
+    dedupe_hash = hashlib.sha256(
+        f"{form.partner_id}:{form.attr_via.value}:{click_id}:{email_hash or ''}".encode()
+    ).hexdigest()
+
+    if request.cookies.get("aff_attr_hash") == dedupe_hash:
+        existing = request.cookies.get("aff_attr_id")
+        if existing:
+            return {"attribution_id": existing}
+
+    with get_db() as db:
+        record = Attribution(
+            click_id=int(click_id), partner_id=form.partner_id, attr_via=form.attr_via
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+
+    expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+    response.set_cookie(
+        key="aff_attr_id",
+        value=str(record.id),
+        expires=expires,
+        httponly=True,
+        samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+        secure=WEBUI_AUTH_COOKIE_SECURE,
+    )
+    response.set_cookie(
+        key="aff_attr_hash",
+        value=dedupe_hash,
+        expires=expires,
+        httponly=True,
+        samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+        secure=WEBUI_AUTH_COOKIE_SECURE,
+    )
+    if email_hash:
+        response.set_cookie(
+            key="aff_email_hash",
+            value=email_hash,
+            expires=expires,
+            httponly=True,
+            samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+            secure=WEBUI_AUTH_COOKIE_SECURE,
+        )
+
+    return {"attribution_id": record.id}

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -56,6 +56,7 @@ from typing import Optional, List
 from ssl import CERT_NONE, CERT_REQUIRED, PROTOCOL_TLS
 
 from open_webui.utils.promotion import create_free_signup_credits
+from open_webui.core.affiliate import resolve_attribution_on_auth
 
 if ENABLE_LDAP.value:
     from ldap3 import Server, Connection, NONE, Tls
@@ -438,6 +439,9 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
             secure=WEBUI_AUTH_COOKIE_SECURE,
         )
 
+        # Resolve any affiliate attribution details for this authenticated user
+        resolve_attribution_on_auth(user.email, request, response)
+
         user_permissions = get_permissions(
             user.id, request.app.state.config.USER_PERMISSIONS
         )
@@ -547,6 +551,9 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
                         "user": user.model_dump_json(exclude_none=True),
                     },
                 )
+
+            # Resolve any affiliate attribution information for this new user
+            resolve_attribution_on_auth(user.email, request, response)
 
             user_permissions = get_permissions(
                 user.id, request.app.state.config.USER_PERMISSIONS


### PR DESCRIPTION
## Summary
- add affiliate click and attribution tracking endpoints with cookie dedupe
- renew affiliate attribution on auth and provide attribution priority helper
- wire up affiliate tracking router in FastAPI app

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pip install typer` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a10538ce548333812fe58b7de55550