### PR TITLE
Add affiliate payout endpoints and encryption

### DIFF
--- a/backend/open_webui/core/affiliate/crypto.py
+++ b/backend/open_webui/core/affiliate/crypto.py
@@ -1,0 +1,25 @@
+import json
+import os
+from typing import Any
+
+from cryptography.fernet import Fernet
+
+# Environment variable holding base64 encoded key
+_KEY_ENV = "AFFILIATE_PAYOUT_ENCRYPTION_KEY"
+_key = os.environ.get(_KEY_ENV)
+if not _key:
+    # Generate ephemeral key if none provided
+    _key = Fernet.generate_key().decode()
+fernet = Fernet(_key.encode() if isinstance(_key, str) else _key)
+
+
+def encrypt_details(details: Any) -> str:
+    """Encrypt payout details dictionary to a string."""
+    data = json.dumps(details).encode()
+    return fernet.encrypt(data).decode()
+
+
+def decrypt_details(token: str) -> Any:
+    """Decrypt payout details string back to dictionary."""
+    data = fernet.decrypt(token.encode()).decode()
+    return json.loads(data)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -85,6 +85,8 @@ from open_webui.routers import (
     quota_policy # Added quota_policy router
 )
 from open_webui.routers.affiliate import tracking as affiliate_tracking
+from open_webui.routers.affiliate import payouts as affiliate_payouts
+from open_webui.routers.admin.affiliate import payouts as admin_affiliate_payouts
 
 from open_webui.routers.retrieval import (
     get_embedding_function,
@@ -1107,6 +1109,12 @@ app.include_router(discount.router, prefix="/api/v1/discount", tags=["discount"]
 app.include_router(plans.router, prefix="/api/v1/plans", tags=["plans"])
 app.include_router(quota_policy.router, prefix="/api/v1/quota_policies", tags=["quota_policies"]) # Added quota_policy router
 app.include_router(affiliate_tracking.router, prefix="/t/affiliate", tags=["affiliate"])
+app.include_router(affiliate_payouts.router, prefix="/api/v1/affiliate", tags=["affiliate"])
+app.include_router(
+    admin_affiliate_payouts.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
 
 try:
     audit_level = AuditLevel(AUDIT_LOG_LEVEL)

--- a/backend/open_webui/migrations/versions/23b91a37adcb_add_payout_request_fee_fields.py
+++ b/backend/open_webui/migrations/versions/23b91a37adcb_add_payout_request_fee_fields.py
@@ -1,0 +1,22 @@
+"""add payout requested_amount fee_mmk details"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '23b91a37adcb'
+down_revision = 'f7e8308eaa9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('payout', sa.Column('details', sa.Text(), nullable=True), schema='affiliate')
+    op.add_column('payout', sa.Column('requested_amount', sa.Numeric(), nullable=False, server_default='0'), schema='affiliate')
+    op.add_column('payout', sa.Column('fee_mmk', sa.Numeric(), nullable=False, server_default='0'), schema='affiliate')
+
+
+def downgrade():
+    op.drop_column('payout', 'fee_mmk', schema='affiliate')
+    op.drop_column('payout', 'requested_amount', schema='affiliate')
+    op.drop_column('payout', 'details', schema='affiliate')

--- a/backend/open_webui/models/affiliate/models.py
+++ b/backend/open_webui/models/affiliate/models.py
@@ -159,8 +159,11 @@ class Payout(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     partner_id = Column(String, nullable=False)
+    requested_amount = Column(Numeric, nullable=False)
     total_amount = Column(Numeric, nullable=False)
+    fee_mmk = Column(Numeric, nullable=False, default=0)
     status = Column(String, nullable=False, default="pending")
+    details = Column(Text, nullable=True)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
 
 

--- a/backend/open_webui/routers/admin/affiliate/payouts.py
+++ b/backend/open_webui/routers/admin/affiliate/payouts.py
@@ -1,0 +1,87 @@
+import csv
+import io
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi.responses import Response
+from sqlalchemy import select
+
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Payout
+from open_webui.utils.auth import get_admin_user
+
+router = APIRouter()
+
+
+@router.post("/payouts/{payout_id}/approve")
+def approve_payout(payout_id: str, admin=Depends(get_admin_user)):
+    with get_db() as db:
+        payout = db.get(Payout, payout_id)
+        if not payout:
+            raise HTTPException(status_code=404, detail="Payout not found")
+        payout.status = "approved"
+        db.commit()
+    return {"id": payout_id, "status": "approved"}
+
+
+@router.post("/payouts/{payout_id}/mark-paid")
+def mark_paid(payout_id: str, admin=Depends(get_admin_user)):
+    with get_db() as db:
+        payout = db.get(Payout, payout_id)
+        if not payout:
+            raise HTTPException(status_code=404, detail="Payout not found")
+        payout.status = "paid"
+        db.commit()
+    return {"id": payout_id, "status": "paid"}
+
+
+@router.get("/payouts/export")
+def export_payouts(admin=Depends(get_admin_user)):
+    with get_db() as db:
+        payouts = db.execute(select(Payout)).scalars().all()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow([
+        "id",
+        "partner_id",
+        "requested_amount",
+        "total_amount",
+        "fee_mmk",
+        "status",
+        "created_at",
+    ])
+    for p in payouts:
+        writer.writerow(
+            [
+                p.id,
+                p.partner_id,
+                p.requested_amount,
+                p.total_amount,
+                p.fee_mmk,
+                p.status,
+                p.created_at,
+            ]
+        )
+    return Response(content=buf.getvalue(), media_type="text/csv")
+
+
+@router.post("/payouts/import")
+async def import_payouts(file: UploadFile, admin=Depends(get_admin_user)):
+    data = (await file.read()).decode()
+    reader = csv.DictReader(io.StringIO(data))
+    count = 0
+    with get_db() as db:
+        for row in reader:
+            payout = Payout(
+                id=row.get("id") or None,
+                partner_id=row["partner_id"],
+                requested_amount=row.get("requested_amount", 0),
+                total_amount=row.get("total_amount", 0),
+                fee_mmk=row.get("fee_mmk", 0),
+                status=row.get("status", "pending"),
+                created_at=int(row.get("created_at") or time.time()),
+            )
+            db.merge(payout)
+            count += 1
+        db.commit()
+    return {"imported": count}

--- a/backend/open_webui/routers/affiliate/payouts.py
+++ b/backend/open_webui/routers/affiliate/payouts.py
@@ -1,0 +1,143 @@
+from decimal import Decimal
+import os
+from typing import Any, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from open_webui.core.affiliate.crypto import encrypt_details, decrypt_details
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Commission, CommissionStatusEnum, Payout, PayoutItem
+from open_webui.utils.auth import get_verified_user
+
+router = APIRouter()
+
+
+MIN_PAYOUT = Decimal(os.environ.get("AFFILIATE_MIN_PAYOUT_MMK", "30000"))
+
+
+class PayoutCreateForm(BaseModel):
+    amount: Decimal
+    details: Any
+    fee_mmk: Decimal | None = None
+
+
+@router.post("/payouts")
+def create_payout(form: PayoutCreateForm, user=Depends(get_verified_user)):
+    with get_db() as db:
+        open_payout = (
+            db.query(Payout)
+            .filter(
+                Payout.partner_id == user.id,
+                Payout.status.in_(["pending", "approved"]),
+            )
+            .first()
+        )
+        if open_payout:
+            raise HTTPException(status_code=400, detail="Existing payout request in progress")
+
+        commissions = (
+            db.query(Commission)
+            .outerjoin(PayoutItem, PayoutItem.commission_id == Commission.id)
+            .filter(
+                Commission.partner_id == user.id,
+                Commission.status == CommissionStatusEnum.approved,
+                PayoutItem.id.is_(None),
+            )
+            .order_by(Commission.created_at.asc())
+            .all()
+        )
+        eligible_balance = sum(Decimal(c.amount) for c in commissions)
+        if eligible_balance < MIN_PAYOUT:
+            raise HTTPException(status_code=400, detail="Eligible balance below minimum threshold")
+
+        requested = Decimal(form.amount)
+        if requested < MIN_PAYOUT:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Requested amount must be at least {MIN_PAYOUT}",
+            )
+        if requested > eligible_balance:
+            raise HTTPException(
+                status_code=400,
+                detail="Requested amount exceeds eligible balance",
+            )
+
+        selected: List[Commission] = []
+        total = Decimal("0")
+        for commission in commissions:
+            amt = Decimal(commission.amount)
+            if total + amt > requested:
+                break
+            selected.append(commission)
+            total += amt
+
+        if not selected:
+            raise HTTPException(status_code=400, detail="No commissions selected for payout")
+
+        payout = Payout(
+            partner_id=user.id,
+            requested_amount=requested,
+            total_amount=total,
+            fee_mmk=form.fee_mmk or Decimal("0"),
+            status="pending",
+            details=encrypt_details(form.details),
+        )
+        db.add(payout)
+        db.flush()
+        for commission in selected:
+            db.add(
+                PayoutItem(
+                    payout_id=payout.id,
+                    commission_id=commission.id,
+                    amount=commission.amount,
+                )
+            )
+        db.commit()
+        db.refresh(payout)
+    return {
+        "id": payout.id,
+        "requested_amount": str(payout.requested_amount),
+        "total_amount": str(payout.total_amount),
+        "fee_mmk": str(payout.fee_mmk),
+        "net_amount": str(Decimal(payout.total_amount) - Decimal(payout.fee_mmk or 0)),
+    }
+
+
+class PayoutResponse(BaseModel):
+    id: str
+    requested_amount: Decimal
+    total_amount: Decimal
+    fee_mmk: Decimal
+    net_amount: Decimal
+    status: str
+    details: Any | None = None
+    created_at: int
+
+
+@router.get("/payouts", response_model=List[PayoutResponse])
+def list_payouts(user=Depends(get_verified_user)):
+    with get_db() as db:
+        payouts = (
+            db.query(Payout)
+            .filter(Payout.partner_id == user.id)
+            .order_by(Payout.created_at.desc())
+            .all()
+        )
+    results: List[PayoutResponse] = []
+    for p in payouts:
+        details = decrypt_details(p.details) if p.details else None
+        net = Decimal(p.total_amount) - Decimal(p.fee_mmk or 0)
+        results.append(
+            PayoutResponse(
+                id=p.id,
+                requested_amount=p.requested_amount,
+                total_amount=p.total_amount,
+                fee_mmk=p.fee_mmk,
+                net_amount=net,
+                status=p.status,
+                details=details,
+                created_at=p.created_at,
+            )
+        )
+    return results


### PR DESCRIPTION
## Summary
- add partner endpoints for creating and listing affiliate payout batches
- add admin endpoints to approve/mark-paid payouts and CSV import/export
- persist payout batches and items with encrypted payout details
- allow partners to specify withdrawal amount when creating a payout
- enforce configurable minimum withdrawal thresholds, FIFO commission selection without splitting, and optional payout fees

## Testing
- `PYTHONPATH=backend pytest` *(fails: ModuleNotFoundError: No module named 'test.util'; ModuleNotFoundError: No module named 'moto'; ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a19cc02ca48333b951e8875c8f979e