### PR TITLE
feat(affiliate): add partner management and analytics endpoints

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -86,6 +86,8 @@ from open_webui.routers import (
 )
 from open_webui.routers.affiliate import tracking as affiliate_tracking
 from open_webui.routers.affiliate import payouts as affiliate_payouts
+from open_webui.routers.affiliate import partners as affiliate_partners
+from open_webui.routers.affiliate import analytics as affiliate_analytics
 from open_webui.routers.admin.affiliate import payouts as admin_affiliate_payouts
 
 from open_webui.routers.retrieval import (
@@ -1110,6 +1112,8 @@ app.include_router(plans.router, prefix="/api/v1/plans", tags=["plans"])
 app.include_router(quota_policy.router, prefix="/api/v1/quota_policies", tags=["quota_policies"]) # Added quota_policy router
 app.include_router(affiliate_tracking.router, prefix="/t/affiliate", tags=["affiliate"])
 app.include_router(affiliate_payouts.router, prefix="/api/v1/affiliate", tags=["affiliate"])
+app.include_router(affiliate_partners.router, prefix="/api/v1/affiliate", tags=["affiliate"])
+app.include_router(affiliate_analytics.router, prefix="/api/v1/affiliate", tags=["affiliate"])
 app.include_router(
     admin_affiliate_payouts.router,
     prefix="/api/v1/admin/affiliate",

--- a/backend/open_webui/routers/affiliate/__init__.py
+++ b/backend/open_webui/routers/affiliate/__init__.py
@@ -1,3 +1,3 @@
-from . import tracking
+from . import tracking, payouts, partners, analytics
 
-__all__ = ["tracking"]
+__all__ = ["tracking", "payouts", "partners", "analytics"]

--- a/backend/open_webui/routers/affiliate/analytics.py
+++ b/backend/open_webui/routers/affiliate/analytics.py
@@ -1,0 +1,48 @@
+from collections import defaultdict
+from decimal import Decimal
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Click, Attribution, Commission
+from open_webui.utils.auth import get_verified_user
+
+router = APIRouter()
+
+
+class TimeseriesItem(BaseModel):
+    day: int
+    clicks: int
+    attributions: int
+    commissions: Decimal
+
+
+@router.get("/analytics/timeseries", response_model=List[TimeseriesItem])
+def analytics_timeseries(user=Depends(get_verified_user)):
+    """Return aggregated affiliate metrics grouped by day."""
+    data: dict[int, dict[str, Decimal | int]] = defaultdict(
+        lambda: {"clicks": 0, "attributions": 0, "commissions": Decimal("0")}
+    )
+    with get_db() as db:
+        for row in db.query(Click).filter(Click.partner_id == user.id).all():
+            day = row.created_at - row.created_at % 86400
+            data[day]["clicks"] += 1
+        for row in db.query(Attribution).filter(Attribution.partner_id == user.id).all():
+            day = row.created_at - row.created_at % 86400
+            data[day]["attributions"] += 1
+        for row in db.query(Commission).filter(Commission.partner_id == user.id).all():
+            day = row.created_at - row.created_at % 86400
+            data[day]["commissions"] += Decimal(row.amount)
+    results: List[TimeseriesItem] = []
+    for day, values in sorted(data.items()):
+        results.append(
+            TimeseriesItem(
+                day=day,
+                clicks=int(values["clicks"]),
+                attributions=int(values["attributions"]),
+                commissions=Decimal(values["commissions"]),
+            )
+        )
+    return results

--- a/backend/open_webui/routers/affiliate/partners.py
+++ b/backend/open_webui/routers/affiliate/partners.py
@@ -1,0 +1,195 @@
+from decimal import Decimal
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import text
+
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import (
+    Link,
+    Coupon,
+    Commission,
+    CommissionAdjustment,
+    CommissionTypeEnum,
+    CommissionStatusEnum,
+)
+from open_webui.utils.auth import get_verified_user
+
+router = APIRouter()
+
+
+class PartnerMeResponse(BaseModel):
+    id: str
+    total_commission: Decimal = Decimal("0")
+
+
+@router.get("/partners/me", response_model=PartnerMeResponse)
+def get_partner_me(user=Depends(get_verified_user)):
+    """Return basic partner information and totals."""
+    total = Decimal("0")
+    with get_db() as db:
+        result = db.execute(
+            text(
+                "SELECT total_amount FROM affiliate.partner_commission_totals WHERE partner_id=:pid"
+            ),
+            {"pid": user.id},
+        ).scalar()
+        if result:
+            total = Decimal(result)
+    return PartnerMeResponse(id=user.id, total_commission=total)
+
+
+class LinkBase(BaseModel):
+    code: str
+    url: str
+
+
+class LinkCreate(LinkBase):
+    pass
+
+
+class LinkUpdate(BaseModel):
+    code: str | None = None
+    url: str | None = None
+
+
+class LinkSchema(LinkBase):
+    id: str
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.post("/partners/me/links", response_model=LinkSchema)
+def create_link(form: LinkCreate, user=Depends(get_verified_user)):
+    with get_db() as db:
+        if db.query(Link).filter(Link.code == form.code).first():
+            raise HTTPException(status_code=400, detail="Code already exists")
+        record = Link(partner_id=user.id, code=form.code, url=form.url)
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        return LinkSchema.model_validate(record, from_attributes=True)
+
+
+@router.get("/partners/me/links", response_model=List[LinkSchema])
+def list_links(user=Depends(get_verified_user)):
+    with get_db() as db:
+        records = (
+            db.query(Link)
+            .filter(Link.partner_id == user.id)
+            .order_by(Link.created_at.desc())
+            .all()
+        )
+        return [LinkSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+@router.put("/partners/me/links/{link_id}", response_model=LinkSchema)
+def update_link(link_id: str, form: LinkUpdate, user=Depends(get_verified_user)):
+    with get_db() as db:
+        record = (
+            db.query(Link)
+            .filter(Link.id == link_id, Link.partner_id == user.id)
+            .first()
+        )
+        if not record:
+            raise HTTPException(status_code=404, detail="Link not found")
+        if form.code and form.code != record.code:
+            if db.query(Link).filter(Link.code == form.code).first():
+                raise HTTPException(status_code=400, detail="Code already exists")
+            record.code = form.code
+        if form.url:
+            record.url = form.url
+        db.commit()
+        db.refresh(record)
+        return LinkSchema.model_validate(record, from_attributes=True)
+
+
+@router.delete("/partners/me/links/{link_id}")
+def delete_link(link_id: str, user=Depends(get_verified_user)):
+    with get_db() as db:
+        record = (
+            db.query(Link)
+            .filter(Link.id == link_id, Link.partner_id == user.id)
+            .first()
+        )
+        if not record:
+            raise HTTPException(status_code=404, detail="Link not found")
+        db.delete(record)
+        db.commit()
+    return {"status": "deleted"}
+
+
+class CouponSchema(BaseModel):
+    id: str
+    code: str
+    discount_percent: Decimal | None = None
+    active: bool
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/partners/me/coupons", response_model=List[CouponSchema])
+def list_coupons(user=Depends(get_verified_user)):
+    with get_db() as db:
+        records = (
+            db.query(Coupon)
+            .filter(Coupon.partner_id == user.id)
+            .order_by(Coupon.created_at.desc())
+            .all()
+        )
+        return [CouponSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+class AdjustmentSchema(BaseModel):
+    id: str
+    amount: Decimal
+    reason: str | None = None
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LedgerEntry(BaseModel):
+    id: str
+    order_id: str
+    type: CommissionTypeEnum
+    status: CommissionStatusEnum
+    amount: Decimal
+    created_at: int
+    adjustments: List[AdjustmentSchema] = []
+
+
+@router.get("/partners/me/ledger", response_model=List[LedgerEntry])
+def get_ledger(user=Depends(get_verified_user)):
+    with get_db() as db:
+        commissions = (
+            db.query(Commission)
+            .filter(Commission.partner_id == user.id)
+            .order_by(Commission.created_at.desc())
+            .all()
+        )
+        results: List[LedgerEntry] = []
+        for c in commissions:
+            adjustments = (
+                db.query(CommissionAdjustment)
+                .filter(CommissionAdjustment.commission_id == c.id)
+                .all()
+            )
+            results.append(
+                LedgerEntry(
+                    id=c.id,
+                    order_id=c.order_id,
+                    type=c.type,
+                    status=c.status,
+                    amount=c.amount,
+                    created_at=c.created_at,
+                    adjustments=[
+                        AdjustmentSchema.model_validate(a, from_attributes=True)
+                        for a in adjustments
+                    ],
+                )
+            )
+        return results


### PR DESCRIPTION
## Summary
- add partner router for managing links, coupons and ledger
- expose analytics timeseries endpoint for affiliate metrics
- wire new affiliate routers into main app

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a1caa5d4a48333ace6e7968c24d07b