### PR TITLE
feat: add admin affiliate management and RBAC

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -110,6 +110,12 @@ if os.path.exists(f"{DATA_DIR}/config.json"):
 DEFAULT_CONFIG = {
     "version": 0,
     "ui": {},
+    "affiliate": {
+        "commission_rules": {},
+        "lock_period_days": 30,
+        "attribution_policy": "last_click",
+        "cookie_window_days": 30,
+    },
 }
 
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -89,6 +89,10 @@ from open_webui.routers.affiliate import payouts as affiliate_payouts
 from open_webui.routers.affiliate import partners as affiliate_partners
 from open_webui.routers.affiliate import analytics as affiliate_analytics
 from open_webui.routers.admin.affiliate import payouts as admin_affiliate_payouts
+from open_webui.routers.admin.affiliate import applications as admin_affiliate_applications
+from open_webui.routers.admin.affiliate import partners as admin_affiliate_partners
+from open_webui.routers.admin.affiliate import commissions as admin_affiliate_commissions
+from open_webui.routers.admin.affiliate import reports as admin_affiliate_reports
 
 from open_webui.routers.retrieval import (
     get_embedding_function,
@@ -1116,6 +1120,26 @@ app.include_router(affiliate_partners.router, prefix="/api/v1/affiliate", tags=[
 app.include_router(affiliate_analytics.router, prefix="/api/v1/affiliate", tags=["affiliate"])
 app.include_router(
     admin_affiliate_payouts.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_applications.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_partners.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_commissions.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_reports.router,
     prefix="/api/v1/admin/affiliate",
     tags=["admin"],
 )

--- a/backend/open_webui/models/affiliate/models.py
+++ b/backend/open_webui/models/affiliate/models.py
@@ -38,6 +38,7 @@ class CommissionStatusEnum(enum.Enum):
     """Lifecycle status of a commission."""
 
     pending = "pending"
+    review = "review"
     approved = "approved"
     rejected = "rejected"
     paid = "paid"
@@ -114,6 +115,7 @@ class OrderAttribution(Base):
     attribution_id = Column(
         String, ForeignKey("affiliate.attribution.id"), nullable=False
     )
+    lost_to_partner_id = Column(String, nullable=True)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
 
 
@@ -138,6 +140,7 @@ class Commission(Base):
     )
     amount = Column(Numeric, nullable=False)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
+    note = Column(Text, nullable=True)
 
 
 class CommissionAdjustment(Base):

--- a/backend/open_webui/routers/admin/affiliate/applications.py
+++ b/backend/open_webui/routers/admin/affiliate/applications.py
@@ -1,0 +1,65 @@
+import time
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Application
+from open_webui.utils.auth import get_admin_or_support_user
+
+router = APIRouter()
+
+
+class ApplicationSchema(BaseModel):
+    id: str
+    partner_id: str
+    status: str
+    notes: Optional[str] = None
+    created_at: int
+    updated_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/applications", response_model=List[ApplicationSchema])
+def list_applications(
+    status: Optional[str] = None, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        query = db.query(Application)
+        if status:
+            query = query.filter(Application.status == status)
+        records = query.order_by(Application.created_at.desc()).all()
+        return [ApplicationSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+@router.get("/applications/{app_id}", response_model=ApplicationSchema)
+def get_application(app_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        record = db.get(Application, app_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Application not found")
+        return ApplicationSchema.model_validate(record, from_attributes=True)
+
+
+@router.post("/applications/{app_id}/approve")
+def approve_application(app_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        record = db.get(Application, app_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Application not found")
+        record.status = "approved"
+        record.updated_at = int(time.time())
+        db.commit()
+    return {"id": app_id, "status": "approved"}
+
+
+@router.post("/applications/{app_id}/reject")
+def reject_application(app_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        record = db.get(Application, app_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Application not found")
+        record.status = "rejected"
+        record.updated_at = int(time.time())
+        db.commit()
+    return {"id": app_id, "status": "rejected"}

--- a/backend/open_webui/routers/admin/affiliate/commissions.py
+++ b/backend/open_webui/routers/admin/affiliate/commissions.py
@@ -1,0 +1,102 @@
+from decimal import Decimal
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import (
+    Commission,
+    CommissionAdjustment,
+    CommissionStatusEnum,
+)
+from open_webui.utils.auth import get_admin_or_support_user
+
+router = APIRouter()
+
+
+class CommissionSchema(BaseModel):
+    id: str
+    partner_id: str
+    order_id: str
+    type: str
+    status: CommissionStatusEnum
+    amount: Decimal
+    created_at: int
+    note: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/commissions", response_model=List[CommissionSchema])
+def list_commissions(
+    status: Optional[CommissionStatusEnum] = None,
+    partner_id: Optional[str] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    admin=Depends(get_admin_or_support_user),
+):
+    with get_db() as db:
+        query = db.query(Commission)
+        if status:
+            query = query.filter(Commission.status == status)
+        if partner_id:
+            query = query.filter(Commission.partner_id == partner_id)
+        if start:
+            query = query.filter(Commission.created_at >= start)
+        if end:
+            query = query.filter(Commission.created_at <= end)
+        records = query.order_by(Commission.created_at.desc()).all()
+        return [CommissionSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+class ActionForm(BaseModel):
+    note: str | None = None
+
+
+@router.post("/commissions/{commission_id}/approve")
+def approve_commission(
+    commission_id: str, form: ActionForm, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        record = db.get(Commission, commission_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Commission not found")
+        record.status = CommissionStatusEnum.approved
+        if form.note is not None:
+            record.note = form.note
+        db.commit()
+    return {"id": commission_id, "status": "approved"}
+
+
+@router.post("/commissions/{commission_id}/void")
+def void_commission(
+    commission_id: str, form: ActionForm, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        record = db.get(Commission, commission_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Commission not found")
+        record.status = CommissionStatusEnum.rejected
+        if form.note is not None:
+            record.note = form.note
+        db.commit()
+    return {"id": commission_id, "status": "void"}
+
+
+class AdjustmentForm(BaseModel):
+    amount: Decimal
+    reason: Optional[str] = None
+
+
+@router.post("/commissions/{commission_id}/adjust")
+def adjust_commission(
+    commission_id: str, form: AdjustmentForm, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        if not db.get(Commission, commission_id):
+            raise HTTPException(status_code=404, detail="Commission not found")
+        adj = CommissionAdjustment(
+            commission_id=commission_id, amount=form.amount, reason=form.reason
+        )
+        db.add(adj)
+        db.commit()
+    return {"id": commission_id, "adjustment": str(form.amount)}

--- a/backend/open_webui/routers/admin/affiliate/partners.py
+++ b/backend/open_webui/routers/admin/affiliate/partners.py
@@ -1,0 +1,86 @@
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import or_
+from open_webui.internal.db import get_db
+from open_webui.models.users import User
+from open_webui.utils.auth import get_admin_or_support_user
+
+router = APIRouter()
+
+
+class PartnerSchema(BaseModel):
+    id: str
+    name: str
+    email: str
+    role: str
+    info: Optional[dict] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/partners", response_model=List[PartnerSchema])
+def search_partners(q: Optional[str] = None, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        query = db.query(User)
+        if q:
+            like = f"%{q}%"
+            query = query.filter(or_(User.name.ilike(like), User.email.ilike(like)))
+        records = query.all()
+        return [PartnerSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+class PartnerUpdateForm(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    rate_override: Optional[float] = None
+    suspended: Optional[bool] = None
+
+
+@router.put("/partners/{partner_id}", response_model=PartnerSchema)
+def update_partner(
+    partner_id: str, form: PartnerUpdateForm, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        partner = db.get(User, partner_id)
+        if not partner:
+            raise HTTPException(status_code=404, detail="Partner not found")
+        if form.name:
+            partner.name = form.name
+        if form.email:
+            partner.email = form.email
+        info = partner.info or {}
+        if form.rate_override is not None:
+            info["rate_override"] = form.rate_override
+        if form.suspended is not None:
+            info["suspended"] = form.suspended
+        partner.info = info
+        db.commit()
+        db.refresh(partner)
+        return PartnerSchema.model_validate(partner, from_attributes=True)
+
+
+@router.post("/partners/{partner_id}/activate")
+def activate_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        partner = db.get(User, partner_id)
+        if not partner:
+            raise HTTPException(status_code=404, detail="Partner not found")
+        info = partner.info or {}
+        info["suspended"] = False
+        partner.info = info
+        db.commit()
+    return {"id": partner_id, "status": "active"}
+
+
+@router.post("/partners/{partner_id}/suspend")
+def suspend_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        partner = db.get(User, partner_id)
+        if not partner:
+            raise HTTPException(status_code=404, detail="Partner not found")
+        info = partner.info or {}
+        info["suspended"] = True
+        partner.info = info
+        db.commit()
+    return {"id": partner_id, "status": "suspended"}

--- a/backend/open_webui/routers/admin/affiliate/payouts.py
+++ b/backend/open_webui/routers/admin/affiliate/payouts.py
@@ -8,13 +8,13 @@ from sqlalchemy import select
 
 from open_webui.internal.db import get_db
 from open_webui.models.affiliate import Payout, PayoutItem
-from open_webui.utils.auth import get_admin_user
+from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
 
 
 @router.post("/payouts/{payout_id}/approve")
-def approve_payout(payout_id: str, admin=Depends(get_admin_user)):
+def approve_payout(payout_id: str, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
         payout = db.get(Payout, payout_id)
         if not payout:
@@ -30,7 +30,7 @@ def approve_payout(payout_id: str, admin=Depends(get_admin_user)):
 
 
 @router.post("/payouts/{payout_id}/mark-paid")
-def mark_paid(payout_id: str, admin=Depends(get_admin_user)):
+def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
         payout = db.get(Payout, payout_id)
         if not payout:
@@ -41,7 +41,7 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_user)):
 
 
 @router.get("/payouts/export")
-def export_payouts(admin=Depends(get_admin_user)):
+def export_payouts(admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
         payouts = db.execute(select(Payout)).scalars().all()
     buf = io.StringIO()
@@ -73,7 +73,7 @@ def export_payouts(admin=Depends(get_admin_user)):
 
 
 @router.post("/payouts/import")
-async def import_payouts(file: UploadFile, admin=Depends(get_admin_user)):
+async def import_payouts(file: UploadFile, admin=Depends(get_admin_or_support_user)):
     data = (await file.read()).decode()
     reader = csv.DictReader(io.StringIO(data))
     count = 0

--- a/backend/open_webui/routers/admin/affiliate/reports.py
+++ b/backend/open_webui/routers/admin/affiliate/reports.py
@@ -1,0 +1,55 @@
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Commission
+from open_webui.utils.auth import get_admin_or_support_user
+from open_webui.config import CONFIG_DATA, save_config
+
+router = APIRouter()
+
+
+class RollupRow(BaseModel):
+    partner_id: str
+    total: Decimal
+
+
+@router.get("/reports/rollup", response_model=List[RollupRow])
+def rollup_report(status: Optional[str] = None, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        query = db.query(Commission.partner_id, func.sum(Commission.amount))
+        if status:
+            query = query.filter(Commission.status == status)
+        rows = query.group_by(Commission.partner_id).all()
+        return [RollupRow(partner_id=r[0], total=r[1] or 0) for r in rows]
+
+
+@router.get("/settings")
+def get_settings(admin=Depends(get_admin_or_support_user)):
+    return CONFIG_DATA.get("affiliate", {})
+
+
+class AffiliateSettingsForm(BaseModel):
+    commission_rules: Dict[str, Any] | None = None
+    lock_period_days: int | None = None
+    attribution_policy: str | None = None
+    cookie_window_days: int | None = None
+
+
+@router.put("/settings")
+def update_settings(form: AffiliateSettingsForm, admin=Depends(get_admin_or_support_user)):
+    config = CONFIG_DATA.copy()
+    aff = config.get("affiliate", {})
+    if form.commission_rules is not None:
+        aff["commission_rules"] = form.commission_rules
+    if form.lock_period_days is not None:
+        aff["lock_period_days"] = form.lock_period_days
+    if form.attribution_policy is not None:
+        aff["attribution_policy"] = form.attribution_policy
+    if form.cookie_window_days is not None:
+        aff["cookie_window_days"] = form.cookie_window_days
+    config["affiliate"] = aff
+    save_config(config)
+    return aff

--- a/backend/open_webui/routers/affiliate/partners.py
+++ b/backend/open_webui/routers/affiliate/partners.py
@@ -160,6 +160,7 @@ class LedgerEntry(BaseModel):
     amount: Decimal
     created_at: int
     adjustments: List[AdjustmentSchema] = []
+    note: str | None = None
 
 
 @router.get("/partners/me/ledger", response_model=List[LedgerEntry])
@@ -186,6 +187,7 @@ def get_ledger(user=Depends(get_verified_user)):
                     status=c.status,
                     amount=c.amount,
                     created_at=c.created_at,
+                    note=c.note,
                     adjustments=[
                         AdjustmentSchema.model_validate(a, from_attributes=True)
                         for a in adjustments

--- a/backend/open_webui/tasks/affiliate/order_paid_worker.py
+++ b/backend/open_webui/tasks/affiliate/order_paid_worker.py
@@ -20,6 +20,10 @@ from open_webui.models.affiliate import (
     CommissionStatusEnum,
     Payout,
     PayoutItem,
+    Attribution,
+    Coupon,
+    Click,
+    AttrViaEnum,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,23 +41,68 @@ POLL_INTERVAL_SECONDS = 10
 
 
 def _persist_order_attribution(order_id: str, attribution_id: str) -> None:
-    """Persist an order attribution record if it does not exist."""
+    """Persist an order attribution record and handle last-click wins."""
     with get_db() as db:
-        existing = db.execute(
-            select(OrderAttribution).where(
-                OrderAttribution.order_id == order_id,
-                OrderAttribution.attribution_id == attribution_id,
-            )
-        ).scalar_one_or_none()
-        if existing:
+        new_attr = db.get(Attribution, attribution_id)
+        if not new_attr:
             return
+        existing_records = (
+            db.query(OrderAttribution)
+            .filter(OrderAttribution.order_id == order_id)
+            .all()
+        )
+        for existing in existing_records:
+            if existing.attribution_id != attribution_id:
+                prev_attr = db.get(Attribution, existing.attribution_id)
+                if prev_attr and prev_attr.partner_id != new_attr.partner_id:
+                    existing.lost_to_partner_id = new_attr.partner_id
+                    db.query(Commission).filter(
+                        Commission.order_id == order_id,
+                        Commission.partner_id == prev_attr.partner_id,
+                    ).update(
+                        {
+                            "status": CommissionStatusEnum.rejected,
+                            "note": f"Lost attribution to {new_attr.partner_id}",
+                        },
+                        synchronize_session=False,
+                    )
         record = OrderAttribution(order_id=order_id, attribution_id=attribution_id)
         db.add(record)
         db.commit()
 
 
-def _create_commissions(order_id: str, partner_id: str, order_amount: Decimal) -> None:
-    """Create pending commission records based on configured rates."""
+def _create_attribution_from_coupon(coupon_code: str) -> tuple[str, str] | None:
+    """Create an attribution record when only a coupon code is present."""
+    with get_db() as db:
+        coupon = (
+            db.query(Coupon)
+            .filter(Coupon.code == coupon_code, Coupon.active.is_(True))
+            .first()
+        )
+        if not coupon:
+            return None
+        click = Click(partner_id=coupon.partner_id, coupon_id=coupon.id, user_agent="coupon")
+        db.add(click)
+        db.commit()
+        db.refresh(click)
+        attr = Attribution(
+            click_id=click.id, partner_id=coupon.partner_id, attr_via=AttrViaEnum.coupon
+        )
+        db.add(attr)
+        db.commit()
+        db.refresh(attr)
+        return attr.id, coupon.partner_id
+
+
+def _create_commissions(
+    order_id: str,
+    partner_id: str,
+    order_amount: Decimal,
+    *,
+    status: CommissionStatusEnum = CommissionStatusEnum.pending,
+    note: str | None = None,
+) -> None:
+    """Create commission records based on configured rates."""
     with get_db() as db:
         for ctype, rate in PLAN_COMMISSION_RATES.items():
             amount = order_amount * rate
@@ -62,6 +111,8 @@ def _create_commissions(order_id: str, partner_id: str, order_amount: Decimal) -
                 order_id=order_id,
                 type=ctype,
                 amount=amount,
+                status=status,
+                note=note,
             )
             db.add(commission)
             try:
@@ -74,6 +125,20 @@ def _create_commissions(order_id: str, partner_id: str, order_amount: Decimal) -
                     partner_id,
                     ctype.value,
                 )
+
+
+def _void_commissions(order_id: str, reason: str, only_pending: bool = False) -> None:
+    """Set commissions for an order to rejected with a reason."""
+    with get_db() as db:
+        query = db.query(Commission).filter(Commission.order_id == order_id)
+        if only_pending:
+            query = query.filter(Commission.status == CommissionStatusEnum.pending)
+        updated = query.update(
+            {"status": CommissionStatusEnum.rejected, "note": reason},
+            synchronize_session=False,
+        )
+        if updated:
+            db.commit()
 
 
 def _approve_pending_commissions() -> None:
@@ -114,12 +179,14 @@ def _mark_paid_commissions() -> None:
 
 
 async def _process_outbox_events() -> None:
-    """Consume unprocessed order_paid outbox events."""
+    """Consume unprocessed affiliate-related outbox events."""
     with get_db() as db:
         events = (
             db.query(OutboxEvent)
             .filter(
-                OutboxEvent.event_type == "order_paid",
+                OutboxEvent.event_type.in_(
+                    ["order_paid", "payment_rejected", "order_refunded"]
+                ),
                 OutboxEvent.processed_at.is_(None),
             )
             .all()
@@ -131,11 +198,36 @@ async def _process_outbox_events() -> None:
         partner_id = payload.get("partner_id")
         amount = Decimal(str(payload.get("amount", "0")))
         attribution_id = payload.get("attribution_id")
+        coupon_code = payload.get("coupon_code")
+        self_ref = payload.get("self_referral")
 
-        if attribution_id and order_id:
-            _persist_order_attribution(order_id, attribution_id)
-        if order_id and partner_id and amount:
-            _create_commissions(order_id, partner_id, amount)
+        if event.event_type == "order_paid":
+            if not attribution_id and coupon_code:
+                res = _create_attribution_from_coupon(coupon_code)
+                if res:
+                    attribution_id, partner_id = res
+            if attribution_id and order_id:
+                _persist_order_attribution(order_id, attribution_id)
+            if order_id and partner_id and amount:
+                status = (
+                    CommissionStatusEnum.review
+                    if self_ref
+                    else CommissionStatusEnum.pending
+                )
+                note = "Self-referral" if self_ref else None
+                _create_commissions(
+                    order_id,
+                    partner_id,
+                    amount,
+                    status=status,
+                    note=note,
+                )
+        elif event.event_type == "payment_rejected":
+            if order_id:
+                _void_commissions(order_id, "Payment not verified")
+        elif event.event_type == "order_refunded":
+            if order_id:
+                _void_commissions(order_id, "Refund within lock period", only_pending=True)
 
         with get_db() as db:
             db.query(OutboxEvent).filter(OutboxEvent.id == event.id).update(

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -268,7 +268,7 @@ def get_current_user_by_api_key(api_key: str):
 
 
 def get_verified_user(user=Depends(get_current_user)):
-    if user.role not in {"user", "admin"}:
+    if user.role not in {"user", "admin", "support", "finance"}:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -278,6 +278,15 @@ def get_verified_user(user=Depends(get_current_user)):
 
 def get_admin_user(user=Depends(get_current_user)):
     if user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+    return user
+
+
+def get_admin_or_support_user(user=Depends(get_current_user)):
+    if user.role not in {"admin", "support", "finance"}:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,


### PR DESCRIPTION
## Summary
- handle affiliate edge cases for attribution, payment and self-referral
- expose commission notes and lost-attribution indicators
- add support/finance RBAC helpers and allow verified access
- expand config with affiliate settings
- implement admin affiliate routers for applications, partners, commissions, reports

## Testing
- `.venv/bin/python -m pytest -q` *(fails: No module named pytest)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e461523c8333ba96dca26df1aab9