### PR TITLE
Start affiliate background workers

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -511,8 +511,15 @@ async def lifespan(app: FastAPI):
 
     from open_webui.scheduled_tasks import schedule_tasks
     from open_webui.telegram_bot import app as telegram_app
+    from open_webui.tasks.affiliate import (
+        order_paid_worker,
+        outbox_processor,
+    )
 
     schedule_tasks()
+
+    asyncio.create_task(order_paid_worker.worker_loop())
+    asyncio.create_task(outbox_processor.worker_loop())
 
     if TELEGRAM_ENABLED:
         if telegram_app:

--- a/backend/open_webui/models/billing.py
+++ b/backend/open_webui/models/billing.py
@@ -534,6 +534,20 @@ class PaymentOrdersTable:
                     )
                     db.add(audit_record)
 
+                if record.status == PaymentStatusEnum.paid:
+                    from open_webui.models.affiliate import OutboxEvent
+
+                    db.add(
+                        OutboxEvent(
+                            event_type="order_paid_internal",
+                            payload={
+                                "order_id": order_id,
+                                "user_id": record.user_id,
+                                "amount": str(record.amount_mmk),
+                            },
+                        )
+                    )
+
                 # Commit the transaction
                 db.commit()
                 db.refresh(record)

--- a/backend/open_webui/routers/admin/affiliate/payouts.py
+++ b/backend/open_webui/routers/admin/affiliate/payouts.py
@@ -7,7 +7,7 @@ from fastapi.responses import Response
 from sqlalchemy import select
 
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Payout, PayoutItem
+from open_webui.models.affiliate import Payout, PayoutItem, OutboxEvent
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -36,6 +36,16 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
         if not payout:
             raise HTTPException(status_code=404, detail="Payout not found")
         payout.status = "paid"
+        db.add(
+            OutboxEvent(
+                event_type="payout_paid",
+                payload={
+                    "payout_id": payout_id,
+                    "partner_id": payout.partner_id,
+                    "amount": str(payout.total_amount),
+                },
+            )
+        )
         db.commit()
     return {"id": payout_id, "status": "paid"}
 

--- a/backend/open_webui/tasks/affiliate/message_templates.py
+++ b/backend/open_webui/tasks/affiliate/message_templates.py
@@ -1,0 +1,11 @@
+"""Message templates for affiliate lifecycle events."""
+
+from typing import Dict
+
+TEMPLATES: Dict[str, str] = {
+    "order_paid": "✅ Order {order_id} has been paid. Amount: {amount}.",
+    "commission_created": "💰 Commission {commission_id} for order {order_id} created: {amount}.",
+    "commission_approved": "👍 Commission {commission_id} for order {order_id} approved.",
+    "commission_paid": "🎉 Commission {commission_id} for order {order_id} paid.",
+    "payout_paid": "💸 Payout {payout_id} of {amount} has been sent.",
+}

--- a/backend/open_webui/tasks/affiliate/order_paid_worker.py
+++ b/backend/open_webui/tasks/affiliate/order_paid_worker.py
@@ -115,6 +115,17 @@ def _create_commissions(
                 note=note,
             )
             db.add(commission)
+            db.add(
+                OutboxEvent(
+                    event_type="commission_created",
+                    payload={
+                        "commission_id": commission.id,
+                        "order_id": order_id,
+                        "partner_id": partner_id,
+                        "amount": str(amount),
+                    },
+                )
+            )
             try:
                 db.commit()
             except IntegrityError:
@@ -145,16 +156,30 @@ def _approve_pending_commissions() -> None:
     """Move commissions from pending to approved after lock period."""
     threshold = int(time.time()) - LOCK_PERIOD_SECONDS
     with get_db() as db:
-        updated = (
+        commissions = (
             db.query(Commission)
             .filter(
                 Commission.status == CommissionStatusEnum.pending,
                 Commission.created_at <= threshold,
             )
-            .update({"status": CommissionStatusEnum.approved}, synchronize_session=False)
+            .all()
         )
-        if updated:
-            db.commit()
+        if not commissions:
+            return
+        for c in commissions:
+            c.status = CommissionStatusEnum.approved
+            db.add(
+                OutboxEvent(
+                    event_type="commission_approved",
+                    payload={
+                        "commission_id": c.id,
+                        "order_id": c.order_id,
+                        "partner_id": c.partner_id,
+                        "amount": str(c.amount),
+                    },
+                )
+            )
+        db.commit()
 
 
 def _mark_paid_commissions() -> None:
@@ -166,16 +191,30 @@ def _mark_paid_commissions() -> None:
             .filter(Payout.status == "paid")
             .subquery()
         )
-        updated = (
+        commissions = (
             db.query(Commission)
             .filter(
                 Commission.status == CommissionStatusEnum.approved,
                 Commission.id.in_(paid_commission_ids),
             )
-            .update({"status": CommissionStatusEnum.paid}, synchronize_session=False)
+            .all()
         )
-        if updated:
-            db.commit()
+        if not commissions:
+            return
+        for c in commissions:
+            c.status = CommissionStatusEnum.paid
+            db.add(
+                OutboxEvent(
+                    event_type="commission_paid",
+                    payload={
+                        "commission_id": c.id,
+                        "order_id": c.order_id,
+                        "partner_id": c.partner_id,
+                        "amount": str(c.amount),
+                    },
+                )
+            )
+        db.commit()
 
 
 async def _process_outbox_events() -> None:
@@ -185,7 +224,7 @@ async def _process_outbox_events() -> None:
             db.query(OutboxEvent)
             .filter(
                 OutboxEvent.event_type.in_(
-                    ["order_paid", "payment_rejected", "order_refunded"]
+                    ["order_paid_internal", "payment_rejected", "order_refunded"]
                 ),
                 OutboxEvent.processed_at.is_(None),
             )
@@ -201,7 +240,7 @@ async def _process_outbox_events() -> None:
         coupon_code = payload.get("coupon_code")
         self_ref = payload.get("self_referral")
 
-        if event.event_type == "order_paid":
+        if event.event_type == "order_paid_internal":
             if not attribution_id and coupon_code:
                 res = _create_attribution_from_coupon(coupon_code)
                 if res:
@@ -229,11 +268,28 @@ async def _process_outbox_events() -> None:
             if order_id:
                 _void_commissions(order_id, "Refund within lock period", only_pending=True)
 
-        with get_db() as db:
-            db.query(OutboxEvent).filter(OutboxEvent.id == event.id).update(
-                {"processed_at": int(time.time())}
-            )
-            db.commit()
+        if event.event_type == "order_paid_internal":
+            with get_db() as db:
+                db.add(
+                    OutboxEvent(
+                        event_type="order_paid",
+                        payload={
+                            "order_id": order_id,
+                            "partner_id": partner_id,
+                            "amount": str(amount),
+                        },
+                    )
+                )
+                db.query(OutboxEvent).filter(OutboxEvent.id == event.id).update(
+                    {"processed_at": int(time.time())}
+                )
+                db.commit()
+        else:
+            with get_db() as db:
+                db.query(OutboxEvent).filter(OutboxEvent.id == event.id).update(
+                    {"processed_at": int(time.time())}
+                )
+                db.commit()
 
 
 async def worker_loop() -> None:

--- a/backend/open_webui/tasks/affiliate/outbox_processor.py
+++ b/backend/open_webui/tasks/affiliate/outbox_processor.py
@@ -1,0 +1,69 @@
+"""Worker to dispatch affiliate lifecycle notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict
+
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import OutboxEvent
+from open_webui.models.users import Users
+from open_webui.telegram_bot import send_telegram_message
+
+from .message_templates import TEMPLATES
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECONDS = 10
+
+
+async def send_email(to_address: str, subject: str, body: str) -> None:
+    """Placeholder email sender."""
+    logger.info("Email to %s: %s", to_address, body)
+
+
+async def _process_outbox_events() -> None:
+    with get_db() as db:
+        events = (
+            db.query(OutboxEvent)
+            .filter(
+                OutboxEvent.event_type.in_(list(TEMPLATES.keys())),
+                OutboxEvent.processed_at.is_(None),
+            )
+            .all()
+        )
+
+    for event in events:
+        payload: Dict[str, Any] = event.payload or {}
+        partner_id = payload.get("partner_id")
+        user = Users.get_user_by_id(partner_id) if partner_id else None
+        template = TEMPLATES.get(event.event_type, "")
+        try:
+            message = template.format(**payload)
+        except Exception:
+            logger.exception("Failed to render template %s", event.event_type)
+            message = str(payload)
+
+        if user:
+            if user.email:
+                await send_email(user.email, "Affiliate Update", message)
+            if user.telegram_chat_id:
+                await send_telegram_message(user.telegram_chat_id, message)
+
+        with get_db() as db:
+            db.query(OutboxEvent).filter(OutboxEvent.id == event.id).update(
+                {"processed_at": int(time.time())}
+            )
+            db.commit()
+
+
+async def worker_loop() -> None:
+    """Continuously poll outbox events and send notifications."""
+    while True:
+        try:
+            await _process_outbox_events()
+        except Exception:
+            logger.exception("Error running affiliate outbox processor loop")
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary
- run affiliate order-processing and notification workers on app startup

## Testing
- `PYTHONPATH=backend:backend/open_webui pytest -q` *(fails: No module named 'moto'; no such table: config)*

------
https://chatgpt.com/codex/tasks/task_e_68a20766f2d48333a5b37a8c521f192c