### PR TITLE
Revert channel model changes

### DIFF
--- a/backend/open_webui/routers/admin/affiliate/applications.py
+++ b/backend/open_webui/routers/admin/affiliate/applications.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Application
+from open_webui.models.affiliate import Application, FraudFlag
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -16,20 +16,34 @@ class ApplicationSchema(BaseModel):
     notes: Optional[str] = None
     created_at: int
     updated_at: int
+    fraud_flags: List[str] = []
 
     model_config = ConfigDict(from_attributes=True)
 
 
 @router.get("/applications", response_model=List[ApplicationSchema])
 def list_applications(
-    status: Optional[str] = None, admin=Depends(get_admin_or_support_user)
+    status: Optional[str] = None,
+    flagged: bool = False,
+    admin=Depends(get_admin_or_support_user),
 ):
     with get_db() as db:
         query = db.query(Application)
         if status:
             query = query.filter(Application.status == status)
         records = query.order_by(Application.created_at.desc()).all()
-        return [ApplicationSchema.model_validate(r, from_attributes=True) for r in records]
+        results: List[ApplicationSchema] = []
+        for r in records:
+            flags = [
+                f.flag_type
+                for f in db.query(FraudFlag).filter(FraudFlag.partner_id == r.partner_id)
+            ]
+            if flagged and not flags:
+                continue
+            app = ApplicationSchema.model_validate(r, from_attributes=True)
+            app.fraud_flags = flags
+            results.append(app)
+        return results
 
 
 @router.get("/applications/{app_id}", response_model=ApplicationSchema)
@@ -38,7 +52,12 @@ def get_application(app_id: str, admin=Depends(get_admin_or_support_user)):
         record = db.get(Application, app_id)
         if not record:
             raise HTTPException(status_code=404, detail="Application not found")
-        return ApplicationSchema.model_validate(record, from_attributes=True)
+        app = ApplicationSchema.model_validate(record, from_attributes=True)
+        app.fraud_flags = [
+            f.flag_type
+            for f in db.query(FraudFlag).filter(FraudFlag.partner_id == record.partner_id)
+        ]
+        return app
 
 
 @router.post("/applications/{app_id}/approve")
@@ -63,3 +82,14 @@ def reject_application(app_id: str, admin=Depends(get_admin_or_support_user)):
         record.updated_at = int(time.time())
         db.commit()
     return {"id": app_id, "status": "rejected"}
+
+
+@router.post("/applications/{app_id}/flags/review")
+def review_application_flags(app_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        record = db.get(Application, app_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Application not found")
+        db.query(FraudFlag).filter(FraudFlag.partner_id == record.partner_id).delete()
+        db.commit()
+    return {"id": app_id, "flags_cleared": True}

--- a/backend/open_webui/routers/admin/affiliate/commissions.py
+++ b/backend/open_webui/routers/admin/affiliate/commissions.py
@@ -7,6 +7,7 @@ from open_webui.models.affiliate import (
     Commission,
     CommissionAdjustment,
     CommissionStatusEnum,
+    FraudFlag,
 )
 from open_webui.utils.auth import get_admin_or_support_user
 
@@ -22,6 +23,7 @@ class CommissionSchema(BaseModel):
     amount: Decimal
     created_at: int
     note: str | None = None
+    fraud_flags: List[str] = []
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -32,6 +34,7 @@ def list_commissions(
     partner_id: Optional[str] = None,
     start: Optional[int] = None,
     end: Optional[int] = None,
+    flagged: bool = False,
     admin=Depends(get_admin_or_support_user),
 ):
     with get_db() as db:
@@ -45,7 +48,18 @@ def list_commissions(
         if end:
             query = query.filter(Commission.created_at <= end)
         records = query.order_by(Commission.created_at.desc()).all()
-        return [CommissionSchema.model_validate(r, from_attributes=True) for r in records]
+        results: List[CommissionSchema] = []
+        for r in records:
+            flags = [
+                f.flag_type
+                for f in db.query(FraudFlag).filter(FraudFlag.partner_id == r.partner_id)
+            ]
+            if flagged and not flags:
+                continue
+            comm = CommissionSchema.model_validate(r, from_attributes=True)
+            comm.fraud_flags = flags
+            results.append(comm)
+        return results
 
 
 class ActionForm(BaseModel):
@@ -100,3 +114,16 @@ def adjust_commission(
         db.add(adj)
         db.commit()
     return {"id": commission_id, "adjustment": str(form.amount)}
+
+
+@router.post("/commissions/{commission_id}/flags/review")
+def review_commission_flags(
+    commission_id: str, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        record = db.get(Commission, commission_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Commission not found")
+        db.query(FraudFlag).filter(FraudFlag.partner_id == record.partner_id).delete()
+        db.commit()
+    return {"id": commission_id, "flags_cleared": True}

--- a/backend/open_webui/routers/admin/affiliate/partners.py
+++ b/backend/open_webui/routers/admin/affiliate/partners.py
@@ -1,3 +1,4 @@
+import time
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
@@ -35,6 +36,8 @@ class PartnerUpdateForm(BaseModel):
     email: Optional[str] = None
     rate_override: Optional[float] = None
     suspended: Optional[bool] = None
+    terms_version: Optional[str] = None
+    blocked_channels: Optional[List[str]] = None
 
 
 @router.put("/partners/{partner_id}", response_model=PartnerSchema)
@@ -54,6 +57,13 @@ def update_partner(
             info["rate_override"] = form.rate_override
         if form.suspended is not None:
             info["suspended"] = form.suspended
+        if form.terms_version is not None:
+            info["terms"] = {
+                "version": form.terms_version,
+                "accepted_at": int(time.time()),
+            }
+        if form.blocked_channels is not None:
+            info["blocked_channels"] = form.blocked_channels
         partner.info = info
         db.commit()
         db.refresh(partner)

--- a/backend/open_webui/routers/affiliate/partners.py
+++ b/backend/open_webui/routers/affiliate/partners.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import time
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,6 +15,7 @@ from open_webui.models.affiliate import (
     CommissionTypeEnum,
     CommissionStatusEnum,
 )
+from open_webui.models.users import User
 from open_webui.utils.auth import get_verified_user
 
 router = APIRouter()
@@ -35,9 +37,26 @@ def get_partner_me(user=Depends(get_verified_user)):
             ),
             {"pid": user.id},
         ).scalar()
-        if result:
-            total = Decimal(result)
+    if result:
+        total = Decimal(result)
     return PartnerMeResponse(id=user.id, total_commission=total)
+
+
+class TermsAcceptanceForm(BaseModel):
+    version: str
+
+
+@router.post("/partners/me/accept-terms")
+def accept_terms(form: TermsAcceptanceForm, user=Depends(get_verified_user)):
+    with get_db() as db:
+        partner = db.get(User, user.id)
+        if not partner:
+            raise HTTPException(status_code=404, detail="Partner not found")
+        info = partner.info or {}
+        info["terms"] = {"version": form.version, "accepted_at": int(time.time())}
+        partner.info = info
+        db.commit()
+    return {"status": "accepted", "version": form.version}
 
 
 class LinkBase(BaseModel):

--- a/backend/open_webui/routers/affiliate/tracking.py
+++ b/backend/open_webui/routers/affiliate/tracking.py
@@ -1,12 +1,19 @@
 import datetime
 import hashlib
+import time
 
 from fastapi import APIRouter, Request, Response, HTTPException
 from pydantic import BaseModel
 
 from open_webui.env import WEBUI_AUTH_COOKIE_SAME_SITE, WEBUI_AUTH_COOKIE_SECURE
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Click, Attribution, AttrViaEnum
+from open_webui.models.affiliate import (
+    Click,
+    Attribution,
+    AttrViaEnum,
+    FraudFlag,
+)
+from open_webui.models.users import User
 
 router = APIRouter()
 
@@ -96,7 +103,21 @@ async def create_attribution(
         record = Attribution(
             click_id=int(click_id), partner_id=form.partner_id, attr_via=form.attr_via
         )
+
+        flag = None
+        if form.email:
+            partner = db.get(User, form.partner_id)
+            if partner and partner.email and partner.email.lower() == form.email.lower():
+                flag = FraudFlag(
+                    partner_id=form.partner_id,
+                    flag_type="self_referral",
+                    notes="Attribution email matches partner email",
+                    created_at=int(time.time()),
+                )
+
         db.add(record)
+        if flag:
+            db.add(flag)
         db.commit()
         db.refresh(record)
 

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -33,6 +33,13 @@ log.setLevel(SRC_LOG_LEVELS["MODELS"])
 
 router = APIRouter()
 
+
+def _ensure_not_blocked(user, channel_id: str):
+    if user.role != "admin" and user.info and channel_id in user.info.get("blocked_channels", []):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT()
+        )
+
 ############################
 # GetChatList
 ############################
@@ -75,6 +82,8 @@ async def get_channel_by_id(id: str, user=Depends(get_verified_user)):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
+
+    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -152,6 +161,8 @@ async def get_channel_messages(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
+
+    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -231,6 +242,8 @@ async def post_new_message(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
+
+    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -333,6 +346,8 @@ async def get_channel_message(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
+    _ensure_not_blocked(user, id)
+
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -430,6 +445,8 @@ async def update_message_by_id(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
+    _ensure_not_blocked(user, id)
+
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -502,6 +519,8 @@ async def add_reaction_to_message(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
+    _ensure_not_blocked(user, id)
+
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -567,6 +586,8 @@ async def remove_reaction_by_id_and_user_id_and_name(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
+
+    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -636,6 +657,8 @@ async def delete_message_by_id(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
+
+    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -33,13 +33,6 @@ log.setLevel(SRC_LOG_LEVELS["MODELS"])
 
 router = APIRouter()
 
-
-def _ensure_not_blocked(user, channel_id: str):
-    if user.role != "admin" and user.info and channel_id in user.info.get("blocked_channels", []):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT()
-        )
-
 ############################
 # GetChatList
 ############################
@@ -82,8 +75,6 @@ async def get_channel_by_id(id: str, user=Depends(get_verified_user)):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
-
-    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -161,8 +152,6 @@ async def get_channel_messages(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
-
-    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -242,8 +231,6 @@ async def post_new_message(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
-
-    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -346,8 +333,6 @@ async def get_channel_message(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
-    _ensure_not_blocked(user, id)
-
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -445,8 +430,6 @@ async def update_message_by_id(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
-    _ensure_not_blocked(user, id)
-
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -519,8 +502,6 @@ async def add_reaction_to_message(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
 
-    _ensure_not_blocked(user, id)
-
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
     ):
@@ -586,8 +567,6 @@ async def remove_reaction_by_id_and_user_id_and_name(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
-
-    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control
@@ -657,8 +636,6 @@ async def delete_message_by_id(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND
         )
-
-    _ensure_not_blocked(user, id)
 
     if user.role != "admin" and not has_access(
         user.id, type="read", access_control=channel.access_control


### PR DESCRIPTION
## Summary
- revert channel model to previous version, removing blocked-channel filtering

## Testing
- `PYTHONPATH=backend pytest` *(errors: ModuleNotFoundError: No module named 'moto'; ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a23c18a1f08333af249e0bd5c3b8eb