### PR TITLE
feat: expand affiliate models

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -106,6 +106,7 @@ from open_webui.models.functions import Functions
 from open_webui.models.models import Models
 from open_webui.models.users import UserModel, Users
 from open_webui.models.chats import Chats
+from open_webui.models.affiliate import models as affiliate_models  # noqa: F401
 
 from open_webui.config import (
     LICENSE_KEY,

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -14,7 +14,10 @@ from alembic import context
 from open_webui.models.auths import Auth
 from open_webui.env import DATABASE_URL
 from sqlalchemy import engine_from_config, pool
-# from open_webui.internal.db import Base
+from open_webui.internal.db import Base
+# Import models to ensure metadata is populated
+from open_webui.models import users, discount  # noqa: F401
+from open_webui.models.affiliate import models as affiliate_models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -29,8 +32,7 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = Auth.metadata
-# target_metadata = Base.metadata
+target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/backend/open_webui/migrations/versions/a2f3d95bb0f3_add_affiliate_partner_profile_and_audit_log.py
+++ b/backend/open_webui/migrations/versions/a2f3d95bb0f3_add_affiliate_partner_profile_and_audit_log.py
@@ -1,0 +1,78 @@
+"""add affiliate partner profile and audit log"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a2f3d95bb0f3'
+down_revision = '53f1f593d1c2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'partner_profile',
+        sa.Column('partner_id', sa.String(), nullable=False),
+        sa.Column('website', sa.Text(), nullable=True),
+        sa.Column('status', sa.Enum('active', 'inactive', 'suspended', name='partner_status_enum', schema='affiliate'), nullable=False, server_default='active'),
+        sa.Column('type', sa.Enum('individual', 'company', name='partner_type_enum', schema='affiliate'), nullable=False, server_default='individual'),
+        sa.Column('terms', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.BigInteger(), nullable=False),
+        sa.Column('updated_at', sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(['partner_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('partner_id'),
+        schema='affiliate'
+    )
+
+    op.create_table(
+        'audit_log',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('partner_id', sa.String(), nullable=True),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('severity', sa.Enum('info', 'warning', 'critical', name='audit_severity_enum', schema='affiliate'), nullable=False),
+        sa.Column('details', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        schema='affiliate'
+    )
+
+    op.execute("CREATE TYPE affiliate.application_status_enum AS ENUM ('pending','approved','rejected')")
+    op.alter_column('application', 'status', schema='affiliate',
+                    type_=sa.Enum('pending','approved','rejected', name='application_status_enum', schema='affiliate'),
+                    existing_type=sa.String(),
+                    postgresql_using="status::text::affiliate.application_status_enum")
+
+    op.add_column('coupon', sa.Column('expires_at', sa.BigInteger(), nullable=True), schema='affiliate')
+    op.drop_column('coupon', 'discount_percent', schema='affiliate')
+    op.create_foreign_key('fk_coupon_code_discount_code', 'coupon', 'discount_code', ['code'], ['code'], source_schema='affiliate')
+
+    op.add_column('payout', sa.Column('reference', sa.String(), nullable=True, unique=True), schema='affiliate')
+    op.execute("CREATE TYPE affiliate.payout_status_enum AS ENUM ('pending','approved','paid','rejected')")
+    op.alter_column('payout', 'status', schema='affiliate',
+                    type_=sa.Enum('pending','approved','paid','rejected', name='payout_status_enum', schema='affiliate'),
+                    existing_type=sa.String(),
+                    postgresql_using="status::text::affiliate.payout_status_enum")
+
+
+def downgrade():
+    op.alter_column('payout', 'status', schema='affiliate',
+                    type_=sa.String(),
+                    postgresql_using="status::text")
+    op.execute('DROP TYPE affiliate.payout_status_enum')
+    op.drop_column('payout', 'reference', schema='affiliate')
+
+    op.drop_constraint('fk_coupon_code_discount_code', 'coupon', schema='affiliate', type_='foreignkey')
+    op.add_column('coupon', sa.Column('discount_percent', sa.Numeric(), nullable=True), schema='affiliate')
+    op.drop_column('coupon', 'expires_at', schema='affiliate')
+
+    op.alter_column('application', 'status', schema='affiliate',
+                    type_=sa.String(),
+                    postgresql_using="status::text")
+    op.execute('DROP TYPE affiliate.application_status_enum')
+
+    op.drop_table('audit_log', schema='affiliate')
+    op.drop_table('partner_profile', schema='affiliate')
+    op.execute('DROP TYPE affiliate.partner_type_enum')
+    op.execute('DROP TYPE affiliate.partner_status_enum')
+    op.execute('DROP TYPE affiliate.audit_severity_enum')

--- a/backend/open_webui/migrations/versions/c8b9f0e5b6e2_move_payout_info_to_partner_profile.py
+++ b/backend/open_webui/migrations/versions/c8b9f0e5b6e2_move_payout_info_to_partner_profile.py
@@ -1,0 +1,27 @@
+"""move payout info to partner profile"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'c8b9f0e5b6e2'
+down_revision = 'a2f3d95bb0f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'partner_profile',
+        sa.Column('payout_method', sa.String(), nullable=True),
+        schema='affiliate'
+    )
+    op.add_column(
+        'partner_profile',
+        sa.Column('payout_details', sa.Text(), nullable=True),
+        schema='affiliate'
+    )
+
+
+def downgrade():
+    op.drop_column('partner_profile', 'payout_details', schema='affiliate')
+    op.drop_column('partner_profile', 'payout_method', schema='affiliate')

--- a/backend/open_webui/models/affiliate/__init__.py
+++ b/backend/open_webui/models/affiliate/__init__.py
@@ -1,5 +1,6 @@
 from .models import (
     Application,
+    PartnerProfile,
     Link,
     Coupon,
     Click,
@@ -11,13 +12,20 @@ from .models import (
     PayoutItem,
     FraudFlag,
     OutboxEvent,
+    AuditLog,
     AttrViaEnum,
     CommissionTypeEnum,
     CommissionStatusEnum,
+    ApplicationStatusEnum,
+    PartnerStatusEnum,
+    PartnerTypeEnum,
+    PayoutStatusEnum,
+    AuditSeverityEnum,
 )
 
 __all__ = [
     "Application",
+    "PartnerProfile",
     "Link",
     "Coupon",
     "Click",
@@ -29,7 +37,13 @@ __all__ = [
     "PayoutItem",
     "FraudFlag",
     "OutboxEvent",
+    "AuditLog",
     "AttrViaEnum",
     "CommissionTypeEnum",
     "CommissionStatusEnum",
+    "ApplicationStatusEnum",
+    "PartnerStatusEnum",
+    "PartnerTypeEnum",
+    "PayoutStatusEnum",
+    "AuditSeverityEnum",
 ]

--- a/backend/open_webui/models/affiliate/models.py
+++ b/backend/open_webui/models/affiliate/models.py
@@ -14,7 +14,6 @@ from sqlalchemy import (
     Enum as SAEnum,
     UniqueConstraint,
 )
-
 from open_webui.internal.db import Base
 
 
@@ -44,14 +43,81 @@ class CommissionStatusEnum(enum.Enum):
     paid = "paid"
 
 
+class ApplicationStatusEnum(enum.Enum):
+    """Status of a partner application."""
+
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class PartnerStatusEnum(enum.Enum):
+    """Operational status of a partner."""
+
+    active = "active"
+    inactive = "inactive"
+    suspended = "suspended"
+
+
+class PartnerTypeEnum(enum.Enum):
+    """Classification type of partner."""
+
+    individual = "individual"
+    company = "company"
+
+
+class PayoutStatusEnum(enum.Enum):
+    """Lifecycle status of a payout."""
+
+    pending = "pending"
+    approved = "approved"
+    paid = "paid"
+    rejected = "rejected"
+
+
+class AuditSeverityEnum(enum.Enum):
+    """Severity level for audit logging."""
+
+    info = "info"
+    warning = "warning"
+    critical = "critical"
+
+
 class Application(Base):
     __tablename__ = "application"
     __table_args__ = {"schema": "affiliate"}
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     partner_id = Column(String, nullable=False)
-    status = Column(String, nullable=False)
+    status = Column(
+        SAEnum(ApplicationStatusEnum, name="application_status_enum", schema="affiliate"),
+        nullable=False,
+        default=ApplicationStatusEnum.pending,
+    )
     notes = Column(Text, nullable=True)
+    created_at = Column(BigInteger, default=lambda: int(time.time()))
+    updated_at = Column(BigInteger, default=lambda: int(time.time()))
+
+
+class PartnerProfile(Base):
+    __tablename__ = "partner_profile"
+    __table_args__ = {"schema": "affiliate"}
+
+    partner_id = Column(String, ForeignKey("user.id"), primary_key=True)
+    website = Column(Text, nullable=True)
+    status = Column(
+        SAEnum(PartnerStatusEnum, name="partner_status_enum", schema="affiliate"),
+        nullable=False,
+        default=PartnerStatusEnum.active,
+    )
+    type = Column(
+        SAEnum(PartnerTypeEnum, name="partner_type_enum", schema="affiliate"),
+        nullable=False,
+        default=PartnerTypeEnum.individual,
+    )
+    payout_method = Column(String, nullable=True)
+    payout_details = Column(Text, nullable=True)
+    terms = Column(JSON, nullable=True)
     created_at = Column(BigInteger, default=lambda: int(time.time()))
     updated_at = Column(BigInteger, default=lambda: int(time.time()))
 
@@ -73,8 +139,8 @@ class Coupon(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     partner_id = Column(String, nullable=False)
-    code = Column(String, nullable=False, unique=True)
-    discount_percent = Column(Numeric, nullable=True)
+    code = Column(String, ForeignKey("discount_code.code"), nullable=False, unique=True)
+    expires_at = Column(BigInteger, nullable=True)
     active = Column(Boolean, default=True)
     created_at = Column(BigInteger, default=lambda: int(time.time()))
 
@@ -165,7 +231,12 @@ class Payout(Base):
     requested_amount = Column(Numeric, nullable=False)
     total_amount = Column(Numeric, nullable=False)
     fee_mmk = Column(Numeric, nullable=False, default=0)
-    status = Column(String, nullable=False, default="pending")
+    status = Column(
+        SAEnum(PayoutStatusEnum, name="payout_status_enum", schema="affiliate"),
+        nullable=False,
+        default=PayoutStatusEnum.pending,
+    )
+    reference = Column(String, nullable=True, unique=True)
     details = Column(Text, nullable=True)
     approved_mmk = Column(Numeric, nullable=True)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
@@ -204,3 +275,18 @@ class OutboxEvent(Base):
     payload = Column(JSON, nullable=False)
     created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
     processed_at = Column(BigInteger, nullable=True)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+    __table_args__ = {"schema": "affiliate"}
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    partner_id = Column(String, nullable=True)
+    action = Column(String, nullable=False)
+    severity = Column(
+        SAEnum(AuditSeverityEnum, name="audit_severity_enum", schema="affiliate"),
+        nullable=False,
+    )
+    details = Column(JSON, nullable=True)
+    created_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))

--- a/backend/open_webui/routers/admin/affiliate/applications.py
+++ b/backend/open_webui/routers/admin/affiliate/applications.py
@@ -3,7 +3,13 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Application, FraudFlag
+from open_webui.models.affiliate import (
+    Application,
+    FraudFlag,
+    ApplicationStatusEnum,
+    PartnerProfile,
+    PartnerStatusEnum,
+)
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -12,7 +18,7 @@ router = APIRouter()
 class ApplicationSchema(BaseModel):
     id: str
     partner_id: str
-    status: str
+    status: ApplicationStatusEnum
     notes: Optional[str] = None
     created_at: int
     updated_at: int
@@ -23,7 +29,7 @@ class ApplicationSchema(BaseModel):
 
 @router.get("/applications", response_model=List[ApplicationSchema])
 def list_applications(
-    status: Optional[str] = None,
+    status: Optional[ApplicationStatusEnum] = None,
     flagged: bool = False,
     admin=Depends(get_admin_or_support_user),
 ):
@@ -66,20 +72,37 @@ def approve_application(app_id: str, admin=Depends(get_admin_or_support_user)):
         record = db.get(Application, app_id)
         if not record:
             raise HTTPException(status_code=404, detail="Application not found")
-        record.status = "approved"
+        record.status = ApplicationStatusEnum.approved
         record.updated_at = int(time.time())
+        profile = db.get(PartnerProfile, record.partner_id)
+        if profile:
+            profile.status = PartnerStatusEnum.active
+            profile.updated_at = int(time.time())
+        else:
+            profile = PartnerProfile(
+                partner_id=record.partner_id,
+                status=PartnerStatusEnum.active,
+                created_at=int(time.time()),
+                updated_at=int(time.time()),
+            )
+            db.add(profile)
         db.commit()
     return {"id": app_id, "status": "approved"}
 
 
+class ApplicationRejectForm(BaseModel):
+    note: str
+
+
 @router.post("/applications/{app_id}/reject")
-def reject_application(app_id: str, admin=Depends(get_admin_or_support_user)):
+def reject_application(app_id: str, form: ApplicationRejectForm, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
         record = db.get(Application, app_id)
         if not record:
             raise HTTPException(status_code=404, detail="Application not found")
-        record.status = "rejected"
+        record.status = ApplicationStatusEnum.rejected
         record.updated_at = int(time.time())
+        record.notes = form.note
         db.commit()
     return {"id": app_id, "status": "rejected"}
 

--- a/backend/open_webui/routers/admin/affiliate/partners.py
+++ b/backend/open_webui/routers/admin/affiliate/partners.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import or_
 from open_webui.internal.db import get_db
 from open_webui.models.users import User
+from open_webui.models.affiliate import PartnerProfile, PartnerStatusEnum
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -57,14 +58,17 @@ def update_partner(
             info["rate_override"] = form.rate_override
         if form.suspended is not None:
             info["suspended"] = form.suspended
-        if form.terms_version is not None:
-            info["terms"] = {
-                "version": form.terms_version,
-                "accepted_at": int(time.time()),
-            }
         if form.blocked_channels is not None:
             info["blocked_channels"] = form.blocked_channels
         partner.info = info
+
+        if form.terms_version is not None:
+            profile = db.get(PartnerProfile, partner_id)
+            if not profile:
+                profile = PartnerProfile(partner_id=partner_id, status=PartnerStatusEnum.inactive)
+                db.add(profile)
+            profile.terms = {"version": form.terms_version, "accepted_at": int(time.time())}
+            profile.updated_at = int(time.time())
         db.commit()
         db.refresh(partner)
         return PartnerSchema.model_validate(partner, from_attributes=True)

--- a/backend/open_webui/routers/admin/affiliate/payouts.py
+++ b/backend/open_webui/routers/admin/affiliate/payouts.py
@@ -7,7 +7,12 @@ from fastapi.responses import Response
 from sqlalchemy import select
 
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Payout, PayoutItem, OutboxEvent
+from open_webui.models.affiliate import (
+    Payout,
+    PayoutItem,
+    OutboxEvent,
+    PayoutStatusEnum,
+)
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -23,10 +28,10 @@ def approve_payout(payout_id: str, admin=Depends(get_admin_or_support_user)):
         items = db.query(PayoutItem).filter(PayoutItem.payout_id == payout_id).all()
         approved_sum = sum(item.amount for item in items)
 
-        payout.status = "approved"
+        payout.status = PayoutStatusEnum.approved
         payout.approved_mmk = approved_sum
         db.commit()
-    return {"id": payout_id, "status": "approved", "approved_mmk": str(approved_sum)}
+    return {"id": payout_id, "status": PayoutStatusEnum.approved, "approved_mmk": str(approved_sum)}
 
 
 @router.post("/payouts/{payout_id}/mark-paid")
@@ -35,7 +40,7 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
         payout = db.get(Payout, payout_id)
         if not payout:
             raise HTTPException(status_code=404, detail="Payout not found")
-        payout.status = "paid"
+        payout.status = PayoutStatusEnum.paid
         db.add(
             OutboxEvent(
                 event_type="payout_paid",
@@ -47,7 +52,7 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
             )
         )
         db.commit()
-    return {"id": payout_id, "status": "paid"}
+    return {"id": payout_id, "status": PayoutStatusEnum.paid}
 
 
 @router.get("/payouts/export")
@@ -56,16 +61,19 @@ def export_payouts(admin=Depends(get_admin_or_support_user)):
         payouts = db.execute(select(Payout)).scalars().all()
     buf = io.StringIO()
     writer = csv.writer(buf)
-    writer.writerow([
-        "id",
-        "partner_id",
-        "requested_amount",
-        "total_amount",
-        "approved_mmk",
-        "fee_mmk",
-        "status",
-        "created_at",
-    ])
+    writer.writerow(
+        [
+            "id",
+            "partner_id",
+            "requested_amount",
+            "total_amount",
+            "approved_mmk",
+            "fee_mmk",
+            "status",
+            "reference",
+            "created_at",
+        ]
+    )
     for p in payouts:
         writer.writerow(
             [
@@ -75,7 +83,8 @@ def export_payouts(admin=Depends(get_admin_or_support_user)):
                 p.total_amount,
                 p.approved_mmk,
                 p.fee_mmk,
-                p.status,
+                p.status.value,
+                p.reference,
                 p.created_at,
             ]
         )
@@ -96,7 +105,8 @@ async def import_payouts(file: UploadFile, admin=Depends(get_admin_or_support_us
                 total_amount=row.get("total_amount", 0),
                 approved_mmk=row.get("approved_mmk"),
                 fee_mmk=row.get("fee_mmk", 0),
-                status=row.get("status", "pending"),
+                status=PayoutStatusEnum(row.get("status", "pending")),
+                reference=row.get("reference"),
                 created_at=int(row.get("created_at") or time.time()),
             )
             db.merge(payout)

--- a/backend/open_webui/routers/affiliate/partners.py
+++ b/backend/open_webui/routers/affiliate/partners.py
@@ -6,24 +6,62 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import text
 
+from open_webui.core.affiliate.crypto import encrypt_details, decrypt_details
 from open_webui.internal.db import get_db
 from open_webui.models.affiliate import (
+    Application,
+    ApplicationStatusEnum,
     Link,
     Coupon,
     Commission,
     CommissionAdjustment,
     CommissionTypeEnum,
     CommissionStatusEnum,
+    PartnerProfile,
+    PartnerStatusEnum,
+    PartnerTypeEnum,
+    AuditLog,
+    AuditSeverityEnum,
 )
-from open_webui.models.users import User
+from open_webui.models.discount import DiscountCode
 from open_webui.utils.auth import get_verified_user
 
 router = APIRouter()
 
 
+class PartnerProfileSchema(BaseModel):
+    partner_id: str
+    website: str | None = None
+    status: PartnerStatusEnum
+    type: PartnerTypeEnum
+    payout_method: str | None = None
+    payout_details: dict | None = None
+    terms: dict | None = None
+    created_at: int
+    updated_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+def to_profile_schema(profile: PartnerProfile) -> PartnerProfileSchema:
+    return PartnerProfileSchema(
+        partner_id=profile.partner_id,
+        website=profile.website,
+        status=profile.status,
+        type=profile.type,
+        payout_method=profile.payout_method,
+        payout_details=
+            decrypt_details(profile.payout_details) if profile.payout_details else None,
+        terms=profile.terms,
+        created_at=profile.created_at,
+        updated_at=profile.updated_at,
+    )
+
+
 class PartnerMeResponse(BaseModel):
     id: str
     total_commission: Decimal = Decimal("0")
+    profile: PartnerProfileSchema | None = None
 
 
 @router.get("/partners/me", response_model=PartnerMeResponse)
@@ -37,9 +75,11 @@ def get_partner_me(user=Depends(get_verified_user)):
             ),
             {"pid": user.id},
         ).scalar()
+        profile = db.get(PartnerProfile, user.id)
     if result:
         total = Decimal(result)
-    return PartnerMeResponse(id=user.id, total_commission=total)
+    profile_schema = to_profile_schema(profile) if profile else None
+    return PartnerMeResponse(id=user.id, total_commission=total, profile=profile_schema)
 
 
 class TermsAcceptanceForm(BaseModel):
@@ -49,14 +89,111 @@ class TermsAcceptanceForm(BaseModel):
 @router.post("/partners/me/accept-terms")
 def accept_terms(form: TermsAcceptanceForm, user=Depends(get_verified_user)):
     with get_db() as db:
-        partner = db.get(User, user.id)
-        if not partner:
-            raise HTTPException(status_code=404, detail="Partner not found")
-        info = partner.info or {}
-        info["terms"] = {"version": form.version, "accepted_at": int(time.time())}
-        partner.info = info
+        profile = db.get(PartnerProfile, user.id)
+        if not profile:
+            profile = PartnerProfile(partner_id=user.id, status=PartnerStatusEnum.inactive)
+            db.add(profile)
+        profile.terms = {"version": form.version, "accepted_at": int(time.time())}
+        profile.updated_at = int(time.time())
         db.commit()
     return {"status": "accepted", "version": form.version}
+
+
+@router.post("/partners/apply")
+def apply_for_affiliate(user=Depends(get_verified_user)):
+    with get_db() as db:
+        existing = (
+            db.query(Application)
+            .filter(Application.partner_id == user.id)
+            .first()
+        )
+        if existing:
+            raise HTTPException(status_code=400, detail="Application already exists")
+        profile = db.get(PartnerProfile, user.id)
+        if not profile:
+            profile = PartnerProfile(partner_id=user.id, status=PartnerStatusEnum.inactive)
+            db.add(profile)
+        else:
+            profile.status = PartnerStatusEnum.inactive
+            profile.updated_at = int(time.time())
+        application = Application(partner_id=user.id, status=ApplicationStatusEnum.pending)
+        db.add(application)
+        db.commit()
+        return {"id": application.id, "status": application.status}
+
+
+class PartnerProfileUpdate(BaseModel):
+    website: str | None = None
+    status: PartnerStatusEnum | None = None
+    type: PartnerTypeEnum | None = None
+
+
+@router.put("/partners/me/profile", response_model=PartnerProfileSchema)
+def update_profile(form: PartnerProfileUpdate, user=Depends(get_verified_user)):
+    with get_db() as db:
+        profile = db.get(PartnerProfile, user.id)
+        if not profile:
+            profile = PartnerProfile(partner_id=user.id)
+            db.add(profile)
+        if form.website is not None:
+            profile.website = form.website
+        if form.status is not None:
+            profile.status = form.status
+        if form.type is not None:
+            profile.type = form.type
+        profile.updated_at = int(time.time())
+        db.add(
+            AuditLog(
+                partner_id=user.id,
+                action="update_profile",
+                severity=AuditSeverityEnum.info,
+                details={"website": form.website},
+            )
+        )
+        db.commit()
+        db.refresh(profile)
+        return to_profile_schema(profile)
+
+
+class PayoutInfo(BaseModel):
+    method: str | None = None
+    details: dict | None = None
+
+
+@router.get("/partners/me/payout-info", response_model=PayoutInfo)
+def get_payout_info(user=Depends(get_verified_user)):
+    with get_db() as db:
+        profile = db.get(PartnerProfile, user.id)
+        if not profile:
+            raise HTTPException(status_code=404, detail="Partner profile not found")
+        details = decrypt_details(profile.payout_details) if profile.payout_details else None
+        return PayoutInfo(method=profile.payout_method, details=details)
+
+
+@router.put("/partners/me/payout-info", response_model=PayoutInfo)
+def update_payout_info(form: PayoutInfo, user=Depends(get_verified_user)):
+    with get_db() as db:
+        profile = db.get(PartnerProfile, user.id)
+        if not profile:
+            profile = PartnerProfile(partner_id=user.id, status=PartnerStatusEnum.inactive)
+            db.add(profile)
+        if form.method is not None:
+            profile.payout_method = form.method
+        if form.details is not None:
+            profile.payout_details = encrypt_details(form.details)
+        profile.updated_at = int(time.time())
+        db.add(
+            AuditLog(
+                partner_id=user.id,
+                action="update_payout_info",
+                severity=AuditSeverityEnum.info,
+                details={"method": form.method},
+            )
+        )
+        db.commit()
+        db.refresh(profile)
+        details = decrypt_details(profile.payout_details) if profile.payout_details else None
+        return PayoutInfo(method=profile.payout_method, details=details)
 
 
 class LinkBase(BaseModel):
@@ -87,6 +224,14 @@ def create_link(form: LinkCreate, user=Depends(get_verified_user)):
             raise HTTPException(status_code=400, detail="Code already exists")
         record = Link(partner_id=user.id, code=form.code, url=form.url)
         db.add(record)
+        db.add(
+            AuditLog(
+                partner_id=user.id,
+                action="create_link",
+                severity=AuditSeverityEnum.info,
+                details={"link_id": record.id},
+            )
+        )
         db.commit()
         db.refresh(record)
         return LinkSchema.model_validate(record, from_attributes=True)
@@ -136,6 +281,14 @@ def delete_link(link_id: str, user=Depends(get_verified_user)):
         if not record:
             raise HTTPException(status_code=404, detail="Link not found")
         db.delete(record)
+        db.add(
+            AuditLog(
+                partner_id=user.id,
+                action="delete_link",
+                severity=AuditSeverityEnum.warning,
+                details={"link_id": link_id},
+            )
+        )
         db.commit()
     return {"status": "deleted"}
 
@@ -144,6 +297,7 @@ class CouponSchema(BaseModel):
     id: str
     code: str
     discount_percent: Decimal | None = None
+    expires_at: int | None = None
     active: bool
     created_at: int
 
@@ -154,12 +308,27 @@ class CouponSchema(BaseModel):
 def list_coupons(user=Depends(get_verified_user)):
     with get_db() as db:
         records = (
-            db.query(Coupon)
+            db.query(Coupon, DiscountCode)
+            .join(DiscountCode, Coupon.code == DiscountCode.code)
             .filter(Coupon.partner_id == user.id)
             .order_by(Coupon.created_at.desc())
             .all()
         )
-        return [CouponSchema.model_validate(r, from_attributes=True) for r in records]
+        results: List[CouponSchema] = []
+        for c, d in records:
+            results.append(
+                CouponSchema(
+                    id=c.id,
+                    code=d.code,
+                    discount_percent=Decimal(d.discount_percent) if d.discount_percent is not None else None,
+                    expires_at=c.expires_at or d.expires_at,
+                    active=c.active and d.active,
+                    created_at=c.created_at,
+                )
+            )
+        return results
+
+
 
 
 class AdjustmentSchema(BaseModel):

--- a/backend/open_webui/routers/affiliate/payouts.py
+++ b/backend/open_webui/routers/affiliate/payouts.py
@@ -5,9 +5,16 @@ from typing import Any, List
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from open_webui.core.affiliate.crypto import encrypt_details, decrypt_details
+from open_webui.core.affiliate.crypto import decrypt_details
 from open_webui.internal.db import get_db
-from open_webui.models.affiliate import Commission, CommissionStatusEnum, Payout, PayoutItem
+from open_webui.models.affiliate import (
+    Commission,
+    CommissionStatusEnum,
+    Payout,
+    PayoutItem,
+    PayoutStatusEnum,
+    PartnerProfile,
+)
 from open_webui.utils.auth import get_verified_user
 
 router = APIRouter()
@@ -18,7 +25,6 @@ MIN_PAYOUT = Decimal(os.environ.get("AFFILIATE_MIN_PAYOUT_MMK", "30000"))
 
 class PayoutCreateForm(BaseModel):
     amount: Decimal
-    details: Any
     fee_mmk: Decimal | None = None
 
 
@@ -29,7 +35,9 @@ def create_payout(form: PayoutCreateForm, user=Depends(get_verified_user)):
             db.query(Payout)
             .filter(
                 Payout.partner_id == user.id,
-                Payout.status.in_(["pending", "approved"]),
+                Payout.status.in_(
+                    [PayoutStatusEnum.pending, PayoutStatusEnum.approved]
+                ),
             )
             .first()
         )
@@ -75,13 +83,17 @@ def create_payout(form: PayoutCreateForm, user=Depends(get_verified_user)):
         if not selected:
             raise HTTPException(status_code=400, detail="No commissions selected for payout")
 
+        profile = db.get(PartnerProfile, user.id)
+        if not profile or not profile.payout_details:
+            raise HTTPException(status_code=400, detail="Payout information required")
+
         payout = Payout(
             partner_id=user.id,
             requested_amount=requested,
             total_amount=total,
             fee_mmk=form.fee_mmk or Decimal("0"),
-            status="pending",
-            details=encrypt_details(form.details),
+            status=PayoutStatusEnum.pending,
+            details=profile.payout_details,
         )
         db.add(payout)
         db.flush()
@@ -110,7 +122,8 @@ class PayoutResponse(BaseModel):
     total_amount: Decimal
     fee_mmk: Decimal
     net_amount: Decimal
-    status: str
+    status: PayoutStatusEnum
+    reference: str | None = None
     details: Any | None = None
     created_at: int
 
@@ -136,6 +149,7 @@ def list_payouts(user=Depends(get_verified_user)):
                 fee_mmk=p.fee_mmk,
                 net_amount=net,
                 status=p.status,
+                reference=p.reference,
                 details=details,
                 created_at=p.created_at,
             )

--- a/backend/open_webui/tasks/affiliate/order_paid_worker.py
+++ b/backend/open_webui/tasks/affiliate/order_paid_worker.py
@@ -20,11 +20,13 @@ from open_webui.models.affiliate import (
     CommissionStatusEnum,
     Payout,
     PayoutItem,
+    PayoutStatusEnum,
     Attribution,
     Coupon,
     Click,
     AttrViaEnum,
 )
+from open_webui.models.discount import DiscountCode
 
 logger = logging.getLogger(__name__)
 
@@ -74,24 +76,37 @@ def _persist_order_attribution(order_id: str, attribution_id: str) -> None:
 def _create_attribution_from_coupon(coupon_code: str) -> tuple[str, str] | None:
     """Create an attribution record when only a coupon code is present."""
     with get_db() as db:
-        coupon = (
-            db.query(Coupon)
-            .filter(Coupon.code == coupon_code, Coupon.active.is_(True))
+        coupon_row = (
+            db.query(Coupon, DiscountCode)
+            .join(DiscountCode, Coupon.code == DiscountCode.code)
+            .filter(
+                Coupon.code == coupon_code,
+                Coupon.active.is_(True),
+                DiscountCode.active.is_(True),
+                (DiscountCode.expires_at.is_(None)
+                 | (DiscountCode.expires_at > int(time.time()))),
+                (Coupon.expires_at.is_(None) | (Coupon.expires_at > int(time.time()))),
+            )
             .first()
         )
-        if not coupon:
+        if not coupon_row:
             return None
-        click = Click(partner_id=coupon.partner_id, coupon_id=coupon.id, user_agent="coupon")
+        coupon_obj = coupon_row[0]
+        click = Click(
+            partner_id=coupon_obj.partner_id,
+            coupon_id=coupon_obj.id,
+            user_agent="coupon",
+        )
         db.add(click)
         db.commit()
         db.refresh(click)
         attr = Attribution(
-            click_id=click.id, partner_id=coupon.partner_id, attr_via=AttrViaEnum.coupon
+            click_id=click.id, partner_id=coupon_obj.partner_id, attr_via=AttrViaEnum.coupon
         )
         db.add(attr)
         db.commit()
         db.refresh(attr)
-        return attr.id, coupon.partner_id
+        return attr.id, coupon_obj.partner_id
 
 
 def _create_commissions(
@@ -188,7 +203,7 @@ def _mark_paid_commissions() -> None:
         paid_commission_ids = (
             db.query(PayoutItem.commission_id)
             .join(Payout, Payout.id == PayoutItem.payout_id)
-            .filter(Payout.status == "paid")
+            .filter(Payout.status == PayoutStatusEnum.paid)
             .subquery()
         )
         commissions = (


### PR DESCRIPTION
## Summary
- drop redundant LinkMetric model and table
- add partner terms and application flow with admin approvals and notes
- auto-activate partner profiles on approval
- store partner payout info in profile and reuse it when creating payouts

## Testing
- `ruff check backend/open_webui/models/affiliate/models.py backend/open_webui/routers/affiliate/partners.py backend/open_webui/routers/affiliate/payouts.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'moto'; ModuleNotFoundError: No module named 'open_webui')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b1f493d88333ba70fb07f8bdf71b