### PR TITLE
feat: enhance affiliate partner admin and rates

### DIFF
--- a/backend/open_webui/models/affiliate/models.py
+++ b/backend/open_webui/models/affiliate/models.py
@@ -117,6 +117,11 @@ class PartnerProfile(Base):
     )
     payout_method = Column(String, nullable=True)
     payout_details = Column(Text, nullable=True)
+    rates = Column(
+        JSON,
+        nullable=False,
+        default=lambda: {"sales": 0.01, "clicks": 0.005},
+    )
     terms = Column(JSON, nullable=True)
     created_at = Column(BigInteger, default=lambda: int(time.time()))
     updated_at = Column(BigInteger, default=lambda: int(time.time()))

--- a/backend/open_webui/routers/admin/affiliate/partners.py
+++ b/backend/open_webui/routers/admin/affiliate/partners.py
@@ -1,11 +1,20 @@
 import time
+from decimal import Decimal
 from typing import List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import or_
+from sqlalchemy import or_, text
+
+from open_webui.core.affiliate.crypto import encrypt_details, decrypt_details
 from open_webui.internal.db import get_db
 from open_webui.models.users import User
-from open_webui.models.affiliate import PartnerProfile, PartnerStatusEnum
+from open_webui.models.affiliate import (
+    AuditLog,
+    AuditSeverityEnum,
+    PartnerProfile,
+    PartnerStatusEnum,
+)
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -16,73 +25,218 @@ class PartnerSchema(BaseModel):
     name: str
     email: str
     role: str
-    info: Optional[dict] = None
+    status: PartnerStatusEnum | None = None
+    balance: Decimal = Decimal("0")
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class AuditLogSchema(BaseModel):
+    id: str
+    action: str
+    severity: AuditSeverityEnum
+    details: dict | None = None
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PartnerDetailSchema(PartnerSchema):
+    payout_method: str | None = None
+    payout_details: dict | None = None
+    rates: dict | None = None
+    audit_logs: List[AuditLogSchema] = []
 
 
 @router.get("/partners", response_model=List[PartnerSchema])
 def search_partners(q: Optional[str] = None, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
-        query = db.query(User)
+        query = db.query(User, PartnerProfile).outerjoin(
+            PartnerProfile, PartnerProfile.partner_id == User.id
+        )
         if q:
             like = f"%{q}%"
             query = query.filter(or_(User.name.ilike(like), User.email.ilike(like)))
         records = query.all()
-        return [PartnerSchema.model_validate(r, from_attributes=True) for r in records]
+        results: List[PartnerSchema] = []
+        for user, profile in records:
+            bal = db.execute(
+                text(
+                    "SELECT total_amount FROM affiliate.partner_commission_totals WHERE partner_id=:pid"
+                ),
+                {"pid": user.id},
+            ).scalar()
+            balance = Decimal(str(bal)) if bal is not None else Decimal("0")
+            results.append(
+                PartnerSchema(
+                    id=user.id,
+                    name=user.name,
+                    email=user.email,
+                    role=user.role,
+                    status=profile.status if profile else None,
+                    balance=balance,
+                )
+            )
+        return results
+
+
+@router.get("/partners/{partner_id}", response_model=PartnerDetailSchema)
+def get_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        user = db.get(User, partner_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="Partner not found")
+        profile = db.get(PartnerProfile, partner_id)
+        bal = db.execute(
+            text(
+                "SELECT total_amount FROM affiliate.partner_commission_totals WHERE partner_id=:pid"
+            ),
+            {"pid": partner_id},
+        ).scalar()
+        balance = Decimal(str(bal)) if bal is not None else Decimal("0")
+        details = (
+            decrypt_details(profile.payout_details) if profile and profile.payout_details else None
+        )
+        logs = (
+            db.query(AuditLog)
+            .filter(AuditLog.partner_id == partner_id)
+            .order_by(AuditLog.created_at.desc())
+            .limit(20)
+            .all()
+        )
+        return PartnerDetailSchema(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            status=profile.status if profile else None,
+            payout_method=profile.payout_method if profile else None,
+            payout_details=details,
+            rates=profile.rates if profile else None,
+            balance=balance,
+            audit_logs=[AuditLogSchema.model_validate(l, from_attributes=True) for l in logs],
+        )
 
 
 class PartnerUpdateForm(BaseModel):
     name: Optional[str] = None
     email: Optional[str] = None
-    rate_override: Optional[float] = None
-    suspended: Optional[bool] = None
+    status: Optional[PartnerStatusEnum] = None
+    payout_method: Optional[str] = None
+    payout_details: Optional[dict] = None
+    rates: Optional[dict] = None
     terms_version: Optional[str] = None
     blocked_channels: Optional[List[str]] = None
 
 
-@router.put("/partners/{partner_id}", response_model=PartnerSchema)
+@router.put("/partners/{partner_id}", response_model=PartnerDetailSchema)
 def update_partner(
     partner_id: str, form: PartnerUpdateForm, admin=Depends(get_admin_or_support_user)
 ):
     with get_db() as db:
-        partner = db.get(User, partner_id)
-        if not partner:
+        user = db.get(User, partner_id)
+        if not user:
             raise HTTPException(status_code=404, detail="Partner not found")
-        if form.name:
-            partner.name = form.name
-        if form.email:
-            partner.email = form.email
-        info = partner.info or {}
-        if form.rate_override is not None:
-            info["rate_override"] = form.rate_override
-        if form.suspended is not None:
-            info["suspended"] = form.suspended
-        if form.blocked_channels is not None:
-            info["blocked_channels"] = form.blocked_channels
-        partner.info = info
+        profile = db.get(PartnerProfile, partner_id)
+        if not profile:
+            profile = PartnerProfile(partner_id=partner_id, status=PartnerStatusEnum.inactive)
+            db.add(profile)
 
+        changes: dict = {}
+
+        if form.name:
+            user.name = form.name
+            changes["name"] = form.name
+        if form.email:
+            user.email = form.email
+            changes["email"] = form.email
+        if form.status is not None:
+            profile.status = form.status
+            changes["status"] = form.status.value
+        if form.payout_method is not None:
+            profile.payout_method = form.payout_method
+            changes["payout_method"] = form.payout_method
+        if form.payout_details is not None:
+            profile.payout_details = encrypt_details(form.payout_details)
+        if form.rates is not None:
+            if admin.role != "admin":
+                raise HTTPException(status_code=401, detail="Only admin can edit rates")
+            profile.rates = form.rates
+            changes["rates"] = form.rates
+        if form.blocked_channels is not None:
+            info = user.info or {}
+            info["blocked_channels"] = form.blocked_channels
+            user.info = info
         if form.terms_version is not None:
-            profile = db.get(PartnerProfile, partner_id)
-            if not profile:
-                profile = PartnerProfile(partner_id=partner_id, status=PartnerStatusEnum.inactive)
-                db.add(profile)
-            profile.terms = {"version": form.terms_version, "accepted_at": int(time.time())}
-            profile.updated_at = int(time.time())
+            profile.terms = {
+                "version": form.terms_version,
+                "accepted_at": int(time.time()),
+            }
+            changes["terms_version"] = form.terms_version
+
+        profile.updated_at = int(time.time())
+
+        db.add(
+            AuditLog(
+                partner_id=partner_id,
+                action="admin_update_partner",
+                severity=AuditSeverityEnum.info,
+                details=changes,
+            )
+        )
+
         db.commit()
-        db.refresh(partner)
-        return PartnerSchema.model_validate(partner, from_attributes=True)
+        db.refresh(user)
+        db.refresh(profile)
+
+        bal = db.execute(
+            text(
+                "SELECT total_amount FROM affiliate.partner_commission_totals WHERE partner_id=:pid"
+            ),
+            {"pid": partner_id},
+        ).scalar()
+        balance = Decimal(str(bal)) if bal is not None else Decimal("0")
+        details = (
+            decrypt_details(profile.payout_details) if profile.payout_details else None
+        )
+        logs = (
+            db.query(AuditLog)
+            .filter(AuditLog.partner_id == partner_id)
+            .order_by(AuditLog.created_at.desc())
+            .limit(20)
+            .all()
+        )
+        return PartnerDetailSchema(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            status=profile.status,
+            payout_method=profile.payout_method,
+            payout_details=details,
+            rates=profile.rates,
+            balance=balance,
+            audit_logs=[AuditLogSchema.model_validate(l, from_attributes=True) for l in logs],
+        )
 
 
 @router.post("/partners/{partner_id}/activate")
 def activate_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
-        partner = db.get(User, partner_id)
-        if not partner:
-            raise HTTPException(status_code=404, detail="Partner not found")
-        info = partner.info or {}
-        info["suspended"] = False
-        partner.info = info
+        profile = db.get(PartnerProfile, partner_id)
+        if not profile:
+            profile = PartnerProfile(partner_id=partner_id, status=PartnerStatusEnum.active)
+            db.add(profile)
+        else:
+            profile.status = PartnerStatusEnum.active
+            profile.updated_at = int(time.time())
+        db.add(
+            AuditLog(
+                partner_id=partner_id,
+                action="admin_activate_partner",
+                severity=AuditSeverityEnum.info,
+            )
+        )
         db.commit()
     return {"id": partner_id, "status": "active"}
 
@@ -90,11 +244,19 @@ def activate_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
 @router.post("/partners/{partner_id}/suspend")
 def suspend_partner(partner_id: str, admin=Depends(get_admin_or_support_user)):
     with get_db() as db:
-        partner = db.get(User, partner_id)
-        if not partner:
-            raise HTTPException(status_code=404, detail="Partner not found")
-        info = partner.info or {}
-        info["suspended"] = True
-        partner.info = info
+        profile = db.get(PartnerProfile, partner_id)
+        if not profile:
+            profile = PartnerProfile(partner_id=partner_id, status=PartnerStatusEnum.suspended)
+            db.add(profile)
+        else:
+            profile.status = PartnerStatusEnum.suspended
+            profile.updated_at = int(time.time())
+        db.add(
+            AuditLog(
+                partner_id=partner_id,
+                action="admin_suspend_partner",
+                severity=AuditSeverityEnum.warning,
+            )
+        )
         db.commit()
     return {"id": partner_id, "status": "suspended"}

--- a/backend/open_webui/tasks/affiliate/order_paid_worker.py
+++ b/backend/open_webui/tasks/affiliate/order_paid_worker.py
@@ -25,15 +25,12 @@ from open_webui.models.affiliate import (
     Coupon,
     Click,
     AttrViaEnum,
+    PartnerProfile,
 )
 from open_webui.models.discount import DiscountCode
 
 logger = logging.getLogger(__name__)
 
-# Default commission rates per type. These could be loaded from configuration.
-PLAN_COMMISSION_RATES: Dict[CommissionTypeEnum, Decimal] = {
-    CommissionTypeEnum.sale: Decimal("0.10"),
-}
 
 # Number of seconds an order should remain pending before auto-approval
 LOCK_PERIOD_SECONDS = int(60 * 60 * 24 * 30)  # 30 days
@@ -119,38 +116,37 @@ def _create_commissions(
 ) -> None:
     """Create commission records based on configured rates."""
     with get_db() as db:
-        for ctype, rate in PLAN_COMMISSION_RATES.items():
-            amount = order_amount * rate
-            commission = Commission(
-                partner_id=partner_id,
-                order_id=order_id,
-                type=ctype,
-                amount=amount,
-                status=status,
-                note=note,
+        profile = db.get(PartnerProfile, partner_id)
+        rate_map = profile.rates if profile and profile.rates else {}
+        sale_rate = Decimal(str(rate_map.get("sales", 0.01)))
+        amount = order_amount * sale_rate
+        commission = Commission(
+            partner_id=partner_id,
+            order_id=order_id,
+            type=CommissionTypeEnum.sale,
+            amount=amount,
+            status=status,
+            note=note,
+        )
+        db.add(commission)
+        db.add(
+            OutboxEvent(
+                event_type="commission_created",
+                payload={
+                    "commission_id": commission.id,
+                    "order_id": order_id,
+                    "partner_id": partner_id,
+                    "amount": str(amount),
+                },
             )
-            db.add(commission)
-            db.add(
-                OutboxEvent(
-                    event_type="commission_created",
-                    payload={
-                        "commission_id": commission.id,
-                        "order_id": order_id,
-                        "partner_id": partner_id,
-                        "amount": str(amount),
-                    },
-                )
+        )
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            logger.debug(
+                "Commission already exists for order %s partner %s", order_id, partner_id
             )
-            try:
-                db.commit()
-            except IntegrityError:
-                db.rollback()
-                logger.debug(
-                    "Commission already exists for order %s partner %s type %s",
-                    order_id,
-                    partner_id,
-                    ctype.value,
-                )
 
 
 def _void_commissions(order_id: str, reason: str, only_pending: bool = False) -> None:


### PR DESCRIPTION
## Summary
- add rates field to `PartnerProfile` model
- expose partner balances, detail and update endpoints with audit logs
- compute commissions using partner-specific rates

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a4dfa4df2c8333a0c034d7367feec0