### PR TITLE
Add admin affiliate link management with audit logging

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -93,6 +93,7 @@ from open_webui.routers.admin.affiliate import applications as admin_affiliate_a
 from open_webui.routers.admin.affiliate import partners as admin_affiliate_partners
 from open_webui.routers.admin.affiliate import commissions as admin_affiliate_commissions
 from open_webui.routers.admin.affiliate import reports as admin_affiliate_reports
+from open_webui.routers.admin.affiliate import links as admin_affiliate_links
 
 from open_webui.routers.retrieval import (
     get_embedding_function,
@@ -1148,6 +1149,11 @@ app.include_router(
 )
 app.include_router(
     admin_affiliate_reports.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_links.router,
     prefix="/api/v1/admin/affiliate",
     tags=["admin"],
 )

--- a/backend/open_webui/migrations/versions/c59a1d734f9a_add_link_utm_active.py
+++ b/backend/open_webui/migrations/versions/c59a1d734f9a_add_link_utm_active.py
@@ -1,0 +1,28 @@
+"""add utm fields and active flag to affiliate links"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c59a1d734f9a'
+down_revision = '23b91a37adcb'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('link', sa.Column('utm_source', sa.String(), nullable=True), schema='affiliate')
+    op.add_column('link', sa.Column('utm_medium', sa.String(), nullable=True), schema='affiliate')
+    op.add_column('link', sa.Column('utm_campaign', sa.String(), nullable=True), schema='affiliate')
+    op.add_column('link', sa.Column('utm_term', sa.String(), nullable=True), schema='affiliate')
+    op.add_column('link', sa.Column('utm_content', sa.String(), nullable=True), schema='affiliate')
+    op.add_column('link', sa.Column('active', sa.Boolean(), nullable=False, server_default='true'), schema='affiliate')
+
+
+def downgrade():
+    op.drop_column('link', 'active', schema='affiliate')
+    op.drop_column('link', 'utm_content', schema='affiliate')
+    op.drop_column('link', 'utm_term', schema='affiliate')
+    op.drop_column('link', 'utm_campaign', schema='affiliate')
+    op.drop_column('link', 'utm_medium', schema='affiliate')
+    op.drop_column('link', 'utm_source', schema='affiliate')

--- a/backend/open_webui/models/affiliate/models.py
+++ b/backend/open_webui/models/affiliate/models.py
@@ -130,6 +130,12 @@ class Link(Base):
     partner_id = Column(String, nullable=False)
     code = Column(String, nullable=False, unique=True)
     url = Column(Text, nullable=False)
+    utm_source = Column(String, nullable=True)
+    utm_medium = Column(String, nullable=True)
+    utm_campaign = Column(String, nullable=True)
+    utm_term = Column(String, nullable=True)
+    utm_content = Column(String, nullable=True)
+    active = Column(Boolean, default=True)
     created_at = Column(BigInteger, default=lambda: int(time.time()))
 
 

--- a/backend/open_webui/routers/admin/affiliate/links.py
+++ b/backend/open_webui/routers/admin/affiliate/links.py
@@ -1,0 +1,157 @@
+import time
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from open_webui.internal.db import get_db
+from open_webui.models.affiliate import Link, AuditLog, AuditSeverityEnum
+from open_webui.utils.auth import get_admin_or_support_user
+
+router = APIRouter()
+
+
+class LinkSchema(BaseModel):
+    id: str
+    partner_id: str
+    code: str
+    url: str
+    utm_source: Optional[str] = None
+    utm_medium: Optional[str] = None
+    utm_campaign: Optional[str] = None
+    utm_term: Optional[str] = None
+    utm_content: Optional[str] = None
+    active: bool
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/links", response_model=List[LinkSchema])
+def list_links(
+    partner_id: Optional[str] = None,
+    active: Optional[bool] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    admin=Depends(get_admin_or_support_user),
+):
+    with get_db() as db:
+        query = db.query(Link)
+        if partner_id:
+            query = query.filter(Link.partner_id == partner_id)
+        if active is not None:
+            query = query.filter(Link.active == active)
+        if start:
+            query = query.filter(Link.created_at >= start)
+        if end:
+            query = query.filter(Link.created_at <= end)
+        records = query.order_by(Link.created_at.desc()).all()
+        return [LinkSchema.model_validate(r, from_attributes=True) for r in records]
+
+
+class LinkCreateForm(BaseModel):
+    partner_id: str
+    code: str
+    url: str
+    utm_source: Optional[str] = None
+    utm_medium: Optional[str] = None
+    utm_campaign: Optional[str] = None
+    utm_term: Optional[str] = None
+    utm_content: Optional[str] = None
+    active: Optional[bool] = True
+
+
+@router.post("/links", response_model=LinkSchema)
+def create_link(form: LinkCreateForm, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        if db.query(Link).filter(Link.code == form.code).first():
+            raise HTTPException(status_code=400, detail="Link code already exists")
+        link = Link(
+            partner_id=form.partner_id,
+            code=form.code,
+            url=form.url,
+            utm_source=form.utm_source,
+            utm_medium=form.utm_medium,
+            utm_campaign=form.utm_campaign,
+            utm_term=form.utm_term,
+            utm_content=form.utm_content,
+            active=form.active if form.active is not None else True,
+            created_at=int(time.time()),
+        )
+        db.add(link)
+        db.add(
+            AuditLog(
+                partner_id=form.partner_id,
+                action="create_link",
+                severity=AuditSeverityEnum.info,
+                details={"link_id": link.id},
+            )
+        )
+        db.commit()
+        db.refresh(link)
+        return LinkSchema.model_validate(link, from_attributes=True)
+
+
+class LinkUpdateForm(BaseModel):
+    code: Optional[str] = None
+    url: Optional[str] = None
+    utm_source: Optional[str] = None
+    utm_medium: Optional[str] = None
+    utm_campaign: Optional[str] = None
+    utm_term: Optional[str] = None
+    utm_content: Optional[str] = None
+    active: Optional[bool] = None
+
+
+@router.patch("/links/{link_id}", response_model=LinkSchema)
+def update_link(link_id: str, form: LinkUpdateForm, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        link = db.get(Link, link_id)
+        if not link:
+            raise HTTPException(status_code=404, detail="Link not found")
+        if form.code and form.code != link.code:
+            if db.query(Link).filter(Link.code == form.code).first():
+                raise HTTPException(status_code=400, detail="Link code already exists")
+            link.code = form.code
+        for field in [
+            "url",
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+            "utm_term",
+            "utm_content",
+            "active",
+        ]:
+            value = getattr(form, field)
+            if value is not None:
+                setattr(link, field, value)
+        db.add(
+            AuditLog(
+                partner_id=link.partner_id,
+                action="update_link",
+                severity=AuditSeverityEnum.info,
+                details={"link_id": link.id, "changes": form.model_dump(exclude_none=True)},
+            )
+        )
+        db.commit()
+        db.refresh(link)
+        return LinkSchema.model_validate(link, from_attributes=True)
+
+
+@router.delete("/links/{link_id}")
+def delete_link(link_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        link = db.get(Link, link_id)
+        if not link:
+            raise HTTPException(status_code=404, detail="Link not found")
+        db.delete(link)
+        db.add(
+            AuditLog(
+                partner_id=link.partner_id,
+                action="delete_link",
+                severity=AuditSeverityEnum.warning,
+                details={"link_id": link_id},
+            )
+        )
+        db.commit()
+    return {"id": link_id, "deleted": True}


### PR DESCRIPTION
## Summary
- add UTM and active columns to affiliate links
- provide admin affiliate link CRUD endpoints with filtering and audit logging
- wire router into application and provide migration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e0e088b08333a4851400bbfad40e