### PR TITLE
Expand affiliate commission filters and auditing

### DIFF
--- a/backend/open_webui/routers/admin/affiliate/commissions.py
+++ b/backend/open_webui/routers/admin/affiliate/commissions.py
@@ -7,8 +7,12 @@ from open_webui.models.affiliate import (
     Commission,
     CommissionAdjustment,
     CommissionStatusEnum,
+    CommissionTypeEnum,
     FraudFlag,
+    AuditLog,
+    AuditSeverityEnum,
 )
+from open_webui.models.billing import PaymentOrder
 from open_webui.utils.auth import get_admin_or_support_user
 
 router = APIRouter()
@@ -28,10 +32,22 @@ class CommissionSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-@router.get("/commissions", response_model=List[CommissionSchema])
+class TotalsFooter(BaseModel):
+    total_amount: Decimal
+
+
+class CommissionListResponse(BaseModel):
+    items: List[CommissionSchema]
+    footer: TotalsFooter
+
+
+@router.get("/commissions", response_model=CommissionListResponse)
 def list_commissions(
     status: Optional[CommissionStatusEnum] = None,
+    type: Optional[CommissionTypeEnum] = None,
     partner_id: Optional[str] = None,
+    order_id: Optional[str] = None,
+    plan_id: Optional[str] = None,
     start: Optional[int] = None,
     end: Optional[int] = None,
     flagged: bool = False,
@@ -41,14 +57,22 @@ def list_commissions(
         query = db.query(Commission)
         if status:
             query = query.filter(Commission.status == status)
+        if type:
+            query = query.filter(Commission.type == type)
         if partner_id:
             query = query.filter(Commission.partner_id == partner_id)
+        if order_id:
+            query = query.filter(Commission.order_id == order_id)
+        if plan_id:
+            query = query.join(PaymentOrder, PaymentOrder.order_id == Commission.order_id)
+            query = query.filter(PaymentOrder.plan_id == plan_id)
         if start:
             query = query.filter(Commission.created_at >= start)
         if end:
             query = query.filter(Commission.created_at <= end)
         records = query.order_by(Commission.created_at.desc()).all()
         results: List[CommissionSchema] = []
+        total_amount = Decimal("0")
         for r in records:
             flags = [
                 f.flag_type
@@ -59,7 +83,10 @@ def list_commissions(
             comm = CommissionSchema.model_validate(r, from_attributes=True)
             comm.fraud_flags = flags
             results.append(comm)
-        return results
+            total_amount += Decimal(r.amount)
+        return CommissionListResponse(
+            items=results, footer=TotalsFooter(total_amount=total_amount)
+        )
 
 
 class ActionForm(BaseModel):
@@ -74,9 +101,27 @@ def approve_commission(
         record = db.get(Commission, commission_id)
         if not record:
             raise HTTPException(status_code=404, detail="Commission not found")
+        if record.status == CommissionStatusEnum.approved:
+            return {"id": commission_id, "status": "approved"}
+
+        previous_status = record.status
         record.status = CommissionStatusEnum.approved
         if form.note is not None:
             record.note = form.note
+
+        db.add(
+            AuditLog(
+                partner_id=record.partner_id,
+                action="admin_approve_commission",
+                severity=AuditSeverityEnum.info,
+                details={
+                    "commission_id": commission_id,
+                    "previous_status": previous_status.value,
+                    "note": form.note,
+                    "admin_id": admin.id,
+                },
+            )
+        )
         db.commit()
     return {"id": commission_id, "status": "approved"}
 
@@ -89,9 +134,26 @@ def void_commission(
         record = db.get(Commission, commission_id)
         if not record:
             raise HTTPException(status_code=404, detail="Commission not found")
+        if record.status == CommissionStatusEnum.rejected:
+            return {"id": commission_id, "status": "void"}
+
+        previous_status = record.status
         record.status = CommissionStatusEnum.rejected
         if form.note is not None:
             record.note = form.note
+        db.add(
+            AuditLog(
+                partner_id=record.partner_id,
+                action="admin_void_commission",
+                severity=AuditSeverityEnum.warning,
+                details={
+                    "commission_id": commission_id,
+                    "previous_status": previous_status.value,
+                    "note": form.note,
+                    "admin_id": admin.id,
+                },
+            )
+        )
         db.commit()
     return {"id": commission_id, "status": "void"}
 
@@ -106,12 +168,38 @@ def adjust_commission(
     commission_id: str, form: AdjustmentForm, admin=Depends(get_admin_or_support_user)
 ):
     with get_db() as db:
-        if not db.get(Commission, commission_id):
+        record = db.get(Commission, commission_id)
+        if not record:
             raise HTTPException(status_code=404, detail="Commission not found")
+        existing = (
+            db.query(CommissionAdjustment)
+            .filter(
+                CommissionAdjustment.commission_id == commission_id,
+                CommissionAdjustment.amount == form.amount,
+                CommissionAdjustment.reason == form.reason,
+            )
+            .first()
+        )
+        if existing:
+            return {"id": commission_id, "adjustment": str(existing.amount)}
+
         adj = CommissionAdjustment(
             commission_id=commission_id, amount=form.amount, reason=form.reason
         )
         db.add(adj)
+        db.add(
+            AuditLog(
+                partner_id=record.partner_id,
+                action="admin_adjust_commission",
+                severity=AuditSeverityEnum.info,
+                details={
+                    "commission_id": commission_id,
+                    "amount": str(form.amount),
+                    "reason": form.reason,
+                    "admin_id": admin.id,
+                },
+            )
+        )
         db.commit()
     return {"id": commission_id, "adjustment": str(form.amount)}
 


### PR DESCRIPTION
## Summary
- support full filter set and totals when listing affiliate commissions
- add idempotent approve, void, and adjust handlers with audit log entries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a4f738454883339ad7a8d8e0013e4e