### PR TITLE
Add affiliate order lookup admin endpoint

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -82,18 +82,25 @@ from open_webui.routers import (
     storage,
     discount,
     plans,
-    quota_policy # Added quota_policy router
+    quota_policy,  # Added quota_policy router
 )
 from open_webui.routers.affiliate import tracking as affiliate_tracking
 from open_webui.routers.affiliate import payouts as affiliate_payouts
 from open_webui.routers.affiliate import partners as affiliate_partners
 from open_webui.routers.affiliate import analytics as affiliate_analytics
 from open_webui.routers.admin.affiliate import payouts as admin_affiliate_payouts
-from open_webui.routers.admin.affiliate import applications as admin_affiliate_applications
+from open_webui.routers.admin.affiliate import (
+    applications as admin_affiliate_applications,
+)
 from open_webui.routers.admin.affiliate import partners as admin_affiliate_partners
-from open_webui.routers.admin.affiliate import commissions as admin_affiliate_commissions
+from open_webui.routers.admin.affiliate import (
+    commissions as admin_affiliate_commissions,
+)
 from open_webui.routers.admin.affiliate import reports as admin_affiliate_reports
 from open_webui.routers.admin.affiliate import links as admin_affiliate_links
+from open_webui.routers.admin.affiliate import (
+    order_lookup as admin_affiliate_order_lookup,
+)
 
 from open_webui.routers.retrieval import (
     get_embedding_function,
@@ -382,7 +389,7 @@ from open_webui.config import (
     AUTOCOMPLETE_GENERATION_INPUT_MAX_LENGTH,
     AppConfig,
     reset_config,
-    TELEGRAM_ENABLED
+    TELEGRAM_ENABLED,
 )
 from open_webui.env import (
     AUDIT_EXCLUDED_PATHS,
@@ -1060,8 +1067,8 @@ async def check_url(request: Request, call_next):
 @app.middleware("http")
 async def inspect_websocket(request: Request, call_next):
     if (
-            "/ws/socket.io" in request.url.path
-            and request.query_params.get("transport") == "websocket"
+        "/ws/socket.io" in request.url.path
+        and request.query_params.get("transport") == "websocket"
     ):
         upgrade = (request.headers.get("Upgrade") or "").lower()
         connection = (request.headers.get("Connection") or "").lower().split(",")
@@ -1088,7 +1095,7 @@ app.mount("/ws", socket_app)
 app.include_router(ollama.router, prefix="/ollama", tags=["ollama"])
 app.include_router(openai.router, prefix="/openai", tags=["openai"])
 
-app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"]) 
+app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"])
 app.include_router(tasks.router, prefix="/api/v1/tasks", tags=["tasks"])
 app.include_router(images.router, prefix="/api/v1/images", tags=["images"])
 
@@ -1122,11 +1129,19 @@ app.include_router(billing.router, prefix="/api/v1/billing", tags=["billing"])
 app.include_router(storage.router, prefix="/api/v1/storage", tags=["storage"])
 app.include_router(discount.router, prefix="/api/v1/discount", tags=["discount"])
 app.include_router(plans.router, prefix="/api/v1/plans", tags=["plans"])
-app.include_router(quota_policy.router, prefix="/api/v1/quota_policies", tags=["quota_policies"]) # Added quota_policy router
+app.include_router(
+    quota_policy.router, prefix="/api/v1/quota_policies", tags=["quota_policies"]
+)  # Added quota_policy router
 app.include_router(affiliate_tracking.router, prefix="/t/affiliate", tags=["affiliate"])
-app.include_router(affiliate_payouts.router, prefix="/api/v1/affiliate", tags=["affiliate"])
-app.include_router(affiliate_partners.router, prefix="/api/v1/affiliate", tags=["affiliate"])
-app.include_router(affiliate_analytics.router, prefix="/api/v1/affiliate", tags=["affiliate"])
+app.include_router(
+    affiliate_payouts.router, prefix="/api/v1/affiliate", tags=["affiliate"]
+)
+app.include_router(
+    affiliate_partners.router, prefix="/api/v1/affiliate", tags=["affiliate"]
+)
+app.include_router(
+    affiliate_analytics.router, prefix="/api/v1/affiliate", tags=["affiliate"]
+)
 app.include_router(
     admin_affiliate_payouts.router,
     prefix="/api/v1/admin/affiliate",
@@ -1154,6 +1169,11 @@ app.include_router(
 )
 app.include_router(
     admin_affiliate_links.router,
+    prefix="/api/v1/admin/affiliate",
+    tags=["admin"],
+)
+app.include_router(
+    admin_affiliate_order_lookup.router,
     prefix="/api/v1/admin/affiliate",
     tags=["admin"],
 )
@@ -1187,11 +1207,11 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
         for model in models:
             if model.get("arena"):
                 if has_access(
-                        user.id,
-                        type="read",
-                        access_control=model.get("info", {})
-                                .get("meta", {})
-                                .get("access_control", {}),
+                    user.id,
+                    type="read",
+                    access_control=model.get("info", {})
+                    .get("meta", {})
+                    .get("access_control", {}),
                 ):
                     filtered_models.append(model)
                 continue
@@ -1199,7 +1219,7 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
             model_info = Models.get_model_by_id(model["id"])
             if model_info:
                 if user.id == model_info.user_id or has_access(
-                        user.id, type="read", access_control=model_info.access_control
+                    user.id, type="read", access_control=model_info.access_control
                 ):
                     filtered_models.append(model)
 
@@ -1227,11 +1247,11 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
         for model in models:
             if model.get("arena"):
                 if has_access(
-                        user.id,
-                        type="read",
-                        access_control=model.get("info", {})
-                                .get("meta", {})
-                                .get("access_control", {}),
+                    user.id,
+                    type="read",
+                    access_control=model.get("info", {})
+                    .get("meta", {})
+                    .get("access_control", {}),
                 ):
                     filtered_models.append(model)
                 continue
@@ -1294,9 +1314,9 @@ async def get_base_models(request: Request, user=Depends(get_admin_user)):
 
 @app.post("/api/chat/completions")
 async def chat_completion(
-        request: Request,
-        form_data: dict,
-        user=Depends(get_verified_user),
+    request: Request,
+    form_data: dict,
+    user=Depends(get_verified_user),
 ):
     if not request.app.state.MODELS:
         await get_all_models(request, user=user)
@@ -1343,11 +1363,11 @@ async def chat_completion(
             **(
                 {"function_calling": "native"}
                 if form_data.get("params", {}).get("function_calling") == "native"
-                   or (
-                           model_info
-                           and model_info.params.model_dump().get("function_calling")
-                           == "native"
-                   )
+                or (
+                    model_info
+                    and model_info.params.model_dump().get("function_calling")
+                    == "native"
+                )
                 else {}
             ),
         }
@@ -1396,7 +1416,7 @@ generate_chat_completion = chat_completion
 
 @app.post("/api/chat/completed")
 async def chat_completed(
-        request: Request, form_data: dict, user=Depends(get_verified_user)
+    request: Request, form_data: dict, user=Depends(get_verified_user)
 ):
     try:
         model_item = form_data.pop("model_item", {})
@@ -1415,7 +1435,7 @@ async def chat_completed(
 
 @app.post("/api/chat/actions/{action_id}")
 async def chat_action(
-        request: Request, action_id: str, form_data: dict, user=Depends(get_verified_user)
+    request: Request, action_id: str, form_data: dict, user=Depends(get_verified_user)
 ):
     try:
         model_item = form_data.pop("model_item", {})
@@ -1617,8 +1637,8 @@ async def get_app_latest_release_version(user=Depends(get_verified_user)):
         timeout = aiohttp.ClientTimeout(total=1)
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.get(
-                    "https://api.github.com/repos/open-webui/open-webui/releases/latest",
-                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                "https://api.github.com/repos/open-webui/open-webui/releases/latest",
+                ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as response:
                 response.raise_for_status()
                 data = await response.json()

--- a/backend/open_webui/routers/admin/affiliate/order_lookup.py
+++ b/backend/open_webui/routers/admin/affiliate/order_lookup.py
@@ -1,0 +1,119 @@
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import or_
+
+from open_webui.internal.db import get_db
+from open_webui.models.billing import PaymentOrder, PaymentStatusEnum
+from open_webui.models.users import User
+from open_webui.models.affiliate import (
+    AttrViaEnum,
+    Attribution,
+    Commission,
+    CommissionStatusEnum,
+    CommissionTypeEnum,
+    OrderAttribution,
+)
+from open_webui.utils.auth import get_admin_or_support_user
+
+router = APIRouter()
+
+
+class CommissionSchema(BaseModel):
+    id: str
+    partner_id: str
+    type: CommissionTypeEnum
+    status: CommissionStatusEnum
+    amount: Decimal
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OrderLookupSchema(BaseModel):
+    order_id: str
+    buyer_id: str
+    buyer_email: Optional[str] = None
+    amount_mmk: Decimal
+    status: PaymentStatusEnum
+    partner_id: Optional[str] = None
+    via: Optional[AttrViaEnum] = None
+    commission: Optional[CommissionSchema] = None
+    links: Dict[str, Optional[str]] = {}
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/order-lookup", response_model=List[OrderLookupSchema])
+def order_lookup(
+    order_id: Optional[str] = None,
+    buyer: Optional[str] = None,
+    admin=Depends(get_admin_or_support_user),
+):
+    if not order_id and not buyer:
+        raise HTTPException(status_code=400, detail="order_id or buyer required")
+
+    with get_db() as db:
+        query = (
+            db.query(
+                PaymentOrder,
+                User,
+                OrderAttribution,
+                Attribution,
+                Commission,
+            )
+            .select_from(PaymentOrder)
+            .join(User, PaymentOrder.user_id == User.id)
+            .outerjoin(
+                OrderAttribution, PaymentOrder.order_id == OrderAttribution.order_id
+            )
+            .outerjoin(Attribution, OrderAttribution.attribution_id == Attribution.id)
+            .outerjoin(Commission, PaymentOrder.order_id == Commission.order_id)
+        )
+
+        if order_id:
+            query = query.filter(PaymentOrder.order_id == order_id)
+        if buyer:
+            like = f"%{buyer}%"
+            query = query.filter(or_(User.email.ilike(like), User.id == buyer))
+
+        rows = query.all()
+
+        results: List[OrderLookupSchema] = []
+        for po, user, _oa, attr, comm in rows:
+            links: Dict[str, Optional[str]] = {
+                "order": f"/admin/settings/orders?order_id={po.order_id}",
+                "buyer": f"/admin/users/{po.user_id}",
+            }
+            partner_id = None
+            via = None
+            if attr:
+                partner_id = attr.partner_id
+                via = attr.attr_via
+                links["partner"] = f"/admin/affiliate/partners/{attr.partner_id}"
+            if comm:
+                links["commission"] = (
+                    f"/admin/affiliate/commissions?order_id={po.order_id}"
+                )
+
+            results.append(
+                OrderLookupSchema(
+                    order_id=po.order_id,
+                    buyer_id=po.user_id,
+                    buyer_email=user.email if user else None,
+                    amount_mmk=Decimal(po.amount_mmk),
+                    status=po.status,
+                    partner_id=partner_id,
+                    via=via,
+                    commission=(
+                        CommissionSchema.model_validate(comm, from_attributes=True)
+                        if comm
+                        else None
+                    ),
+                    links=links,
+                )
+            )
+
+        return results


### PR DESCRIPTION
## Summary
- add `/order-lookup` admin endpoint to inspect affiliate data for payment orders
- expose order, partner, via, commission info and helper admin links
- register new router in main application

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a4f91564b8833389447a6781246d5e