### PR TITLE
feat: add affiliate admin client

### DIFF
--- a/src/lib/affiliate-admin/api.ts
+++ b/src/lib/affiliate-admin/api.ts
@@ -1,0 +1,379 @@
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+import type {
+    Application,
+    ApplicationApproveForm,
+    ApplicationRejectForm,
+    Partner,
+    PartnerDetail,
+    PartnerUpdateForm,
+    Commission,
+    CommissionActionForm,
+    CommissionAdjustmentForm,
+    Link,
+    LinkCreateForm,
+    LinkUpdateForm,
+    RollupRow,
+    AffiliateSettings,
+    AffiliateSettingsForm,
+} from './types';
+
+const ADMIN_AFFILIATE_API_BASE_URL = `${WEBUI_API_BASE_URL}/admin/affiliate`;
+
+const jsonHeaders = (token: string) => ({
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+});
+
+const handle = async (res: Response) => {
+    if (!res.ok) {
+        throw await res.json();
+    }
+    return res.json();
+};
+
+// Applications
+export const listApplications = async (
+    token: string,
+    params: {
+        status?: string;
+        from?: number;
+        to?: number;
+        q?: string;
+        page?: number;
+        flagged?: boolean;
+    } = {}
+): Promise<Application[]> => {
+    const query = new URLSearchParams();
+    if (params.status) query.set('status', params.status);
+    if (params.from) query.set('from', String(params.from));
+    if (params.to) query.set('to', String(params.to));
+    if (params.q) query.set('q', params.q);
+    if (params.page) query.set('page', String(params.page));
+    if (params.flagged) query.set('flagged', String(params.flagged));
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/applications?${query.toString()}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const getApplication = async (token: string, appId: string): Promise<Application> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/applications/${appId}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const approveApplication = async (
+    token: string,
+    appId: string,
+    form: ApplicationApproveForm
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/applications/${appId}/approve`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const rejectApplication = async (
+    token: string,
+    appId: string,
+    form: ApplicationRejectForm
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/applications/${appId}/reject`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const reviewApplicationFlags = async (
+    token: string,
+    appId: string
+): Promise<{ id: string; flags_cleared: boolean }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/applications/${appId}/flags/review`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Partners
+export const searchPartners = async (
+    token: string,
+    q?: string
+): Promise<Partner[]> => {
+    const query = q ? `?q=${encodeURIComponent(q)}` : '';
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/partners${query}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const getPartner = async (
+    token: string,
+    partnerId: string
+): Promise<PartnerDetail> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/partners/${partnerId}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const updatePartner = async (
+    token: string,
+    partnerId: string,
+    form: PartnerUpdateForm
+): Promise<PartnerDetail> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/partners/${partnerId}`, {
+        method: 'PUT',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const activatePartner = async (
+    token: string,
+    partnerId: string
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/partners/${partnerId}/activate`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const suspendPartner = async (
+    token: string,
+    partnerId: string
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/partners/${partnerId}/suspend`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Commissions
+export const listCommissions = async (
+    token: string,
+    params: {
+        status?: string;
+        partner_id?: string;
+        start?: number;
+        end?: number;
+        flagged?: boolean;
+    } = {}
+): Promise<Commission[]> => {
+    const query = new URLSearchParams();
+    if (params.status) query.set('status', params.status);
+    if (params.partner_id) query.set('partner_id', params.partner_id);
+    if (params.start) query.set('start', String(params.start));
+    if (params.end) query.set('end', String(params.end));
+    if (params.flagged) query.set('flagged', String(params.flagged));
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/commissions?${query.toString()}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const approveCommission = async (
+    token: string,
+    commissionId: string,
+    form: CommissionActionForm
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/commissions/${commissionId}/approve`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const voidCommission = async (
+    token: string,
+    commissionId: string,
+    form: CommissionActionForm
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/commissions/${commissionId}/void`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const adjustCommission = async (
+    token: string,
+    commissionId: string,
+    form: CommissionAdjustmentForm
+): Promise<{ id: string; adjustment: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/commissions/${commissionId}/adjust`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const reviewCommissionFlags = async (
+    token: string,
+    commissionId: string
+): Promise<{ id: string; flags_cleared: boolean }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/commissions/${commissionId}/flags/review`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Payouts
+export const approvePayout = async (
+    token: string,
+    payoutId: string
+): Promise<{ id: string; status: string; approved_mmk: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/${payoutId}/approve`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const markPayoutPaid = async (
+    token: string,
+    payoutId: string
+): Promise<{ id: string; status: string }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/${payoutId}/mark-paid`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const exportPayouts = async (
+    token: string
+): Promise<string> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/export`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    if (!res.ok) {
+        throw await res.json();
+    }
+    return res.text();
+};
+
+export const importPayouts = async (
+    token: string,
+    file: File
+): Promise<{ imported: number }> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/import`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+    });
+    return handle(res);
+};
+
+// Links
+export const listLinks = async (
+    token: string,
+    params: {
+        partner_id?: string;
+        active?: boolean;
+        start?: number;
+        end?: number;
+    } = {}
+): Promise<Link[]> => {
+    const query = new URLSearchParams();
+    if (params.partner_id) query.set('partner_id', params.partner_id);
+    if (params.active !== undefined) query.set('active', String(params.active));
+    if (params.start) query.set('start', String(params.start));
+    if (params.end) query.set('end', String(params.end));
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/links?${query.toString()}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const createLink = async (
+    token: string,
+    form: LinkCreateForm
+): Promise<Link> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/links`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const updateLink = async (
+    token: string,
+    linkId: string,
+    form: LinkUpdateForm
+): Promise<Link> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/links/${linkId}`, {
+        method: 'PATCH',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};
+
+export const deleteLink = async (
+    token: string,
+    linkId: string
+): Promise<{ id: string; deleted: boolean }> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/links/${linkId}`, {
+        method: 'DELETE',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Reports & Settings
+export const rollupReport = async (
+    token: string,
+    status?: string
+): Promise<RollupRow[]> => {
+    const query = status ? `?status=${encodeURIComponent(status)}` : '';
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/reports/rollup${query}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const getSettings = async (
+    token: string
+): Promise<AffiliateSettings> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/settings`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const updateSettings = async (
+    token: string,
+    form: AffiliateSettingsForm
+): Promise<AffiliateSettings> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/settings`, {
+        method: 'PUT',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(form),
+    });
+    return handle(res);
+};

--- a/src/lib/affiliate-admin/index.ts
+++ b/src/lib/affiliate-admin/index.ts
@@ -1,0 +1,3 @@
+export * from './api';
+export * from './types';
+export * from './stores';

--- a/src/lib/affiliate-admin/stores.ts
+++ b/src/lib/affiliate-admin/stores.ts
@@ -1,0 +1,48 @@
+import { writable } from 'svelte/store';
+import type {
+    AffiliateSettings,
+    PartnerDetail,
+    TableState,
+} from './types';
+import { getSettings, getPartner } from './api';
+
+// Table states for various admin views
+export const applicationsTable = writable<TableState>({ page: 1 });
+export const partnersTable = writable<TableState>({ page: 1 });
+export const commissionsTable = writable<TableState>({ page: 1 });
+export const linksTable = writable<TableState>({ page: 1 });
+
+// Affiliate program settings cache
+export const affiliateSettings = writable<AffiliateSettings | null>(null);
+let settingsFetchedAt = 0;
+const SETTINGS_TTL = 5 * 60 * 1000; // 5 minutes
+
+export const fetchAffiliateSettings = async (token: string) => {
+    const now = Date.now();
+    if (now - settingsFetchedAt < SETTINGS_TTL && settingsFetchedAt !== 0) {
+        return;
+    }
+    const data = await getSettings(token);
+    affiliateSettings.set(data);
+    settingsFetchedAt = now;
+};
+
+// Partner detail lookup cache with TTL
+const partnerCache = new Map<string, { data: PartnerDetail; ts: number }>();
+const PARTNER_TTL = 60 * 1000; // 1 minute
+
+export const getPartnerCached = async (
+    token: string,
+    id: string
+): Promise<PartnerDetail> => {
+    const now = Date.now();
+    const cached = partnerCache.get(id);
+    if (cached && now - cached.ts < PARTNER_TTL) {
+        return cached.data;
+    }
+    const data = await getPartner(token, id);
+    partnerCache.set(id, { data, ts: now });
+    return data;
+};
+
+export const clearPartnerCache = () => partnerCache.clear();

--- a/src/lib/affiliate-admin/types.ts
+++ b/src/lib/affiliate-admin/types.ts
@@ -1,0 +1,137 @@
+export type DecimalString = string;
+
+export interface AuditLog {
+    id: string;
+    action: string;
+    severity: 'info' | 'warning' | 'critical';
+    details?: Record<string, any>;
+    created_at: number;
+}
+
+export interface Partner {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+    status?: 'active' | 'inactive' | 'suspended';
+    balance: DecimalString;
+}
+
+export interface PartnerDetail extends Partner {
+    payout_method?: string;
+    payout_details?: Record<string, any>;
+    rates?: Record<string, any>;
+    audit_logs: AuditLog[];
+}
+
+export interface Application {
+    id: string;
+    partner_id: string;
+    status: 'pending' | 'approved' | 'rejected';
+    notes?: string;
+    created_at: number;
+    updated_at: number;
+    fraud_flags: string[];
+}
+
+export interface ApplicationApproveForm {
+    link_code: string;
+    link_url: string;
+    coupon_code?: string;
+    coupon_discount_percent?: number;
+    coupon_expires_at?: number;
+}
+
+export interface ApplicationRejectForm {
+    note: string;
+}
+
+export interface PartnerUpdateForm {
+    name?: string;
+    email?: string;
+    status?: 'active' | 'inactive' | 'suspended';
+    payout_method?: string;
+    payout_details?: Record<string, any>;
+    rates?: Record<string, any>;
+    terms_version?: string;
+    blocked_channels?: string[];
+}
+
+export interface Commission {
+    id: string;
+    partner_id: string;
+    order_id: string;
+    type: string;
+    status: 'pending' | 'approved' | 'rejected' | 'paid';
+    amount: DecimalString;
+    created_at: number;
+    note?: string;
+    fraud_flags: string[];
+}
+
+export interface CommissionActionForm {
+    note?: string;
+}
+
+export interface CommissionAdjustmentForm {
+    amount: DecimalString;
+    reason?: string;
+}
+
+export interface Link {
+    id: string;
+    partner_id: string;
+    code: string;
+    url: string;
+    utm_source?: string;
+    utm_medium?: string;
+    utm_campaign?: string;
+    utm_term?: string;
+    utm_content?: string;
+    active: boolean;
+    created_at: number;
+}
+
+export interface LinkCreateForm {
+    partner_id: string;
+    code: string;
+    url: string;
+    utm_source?: string;
+    utm_medium?: string;
+    utm_campaign?: string;
+    utm_term?: string;
+    utm_content?: string;
+    active?: boolean;
+}
+
+export interface LinkUpdateForm {
+    code?: string;
+    url?: string;
+    utm_source?: string;
+    utm_medium?: string;
+    utm_campaign?: string;
+    utm_term?: string;
+    utm_content?: string;
+    active?: boolean;
+}
+
+export interface RollupRow {
+    partner_id: string;
+    total: DecimalString;
+}
+
+export interface AffiliateSettings {
+    commission_rules?: Record<string, any>;
+    lock_period_days?: number;
+    attribution_policy?: string;
+    cookie_window_days?: number;
+}
+
+export interface AffiliateSettingsForm extends AffiliateSettings {}
+
+export interface TableState {
+    page: number;
+    query?: string;
+    status?: string;
+    flagged?: boolean;
+}


### PR DESCRIPTION
## Summary
- add TypeScript interfaces for affiliate admin domain
- implement API wrappers for all `/api/v1/admin/affiliate/*` routes
- provide Svelte stores with table state, settings cache and partner TTL cache

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/lib/affiliate-admin --fix` *(fails: ESLint couldn't find config)*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f9386e4c833390aeb2c956100343