### PR TITLE
Add payout listing, CSV export and admin-only payment

### DIFF
--- a/backend/open_webui/routers/admin/affiliate/payouts.py
+++ b/backend/open_webui/routers/admin/affiliate/payouts.py
@@ -2,9 +2,12 @@ import csv
 import io
 import time
 import uuid
+from decimal import Decimal
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import Response
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 
 from open_webui.internal.db import get_db
@@ -13,11 +16,41 @@ from open_webui.models.affiliate import (
     PayoutItem,
     OutboxEvent,
     PayoutStatusEnum,
+    Commission,
+    CommissionStatusEnum,
 )
 from open_webui.models.audit import AuditLog
-from open_webui.utils.auth import get_admin_or_support_user
+from open_webui.utils.auth import get_admin_or_support_user, get_admin_user
 
 router = APIRouter()
+
+
+class PayoutItemSchema(BaseModel):
+    id: str
+    payout_id: str
+    commission_id: str
+    amount: Decimal
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PayoutSchema(BaseModel):
+    id: str
+    partner_id: str
+    requested_amount: Decimal
+    total_amount: Decimal
+    fee_mmk: Decimal
+    status: PayoutStatusEnum
+    reference: str | None = None
+    approved_mmk: Decimal | None = None
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PayoutDetail(PayoutSchema):
+    items: List[PayoutItemSchema] = []
 
 
 @router.post("/payouts/{payout_id}/approve")
@@ -51,11 +84,15 @@ def approve_payout(payout_id: str, admin=Depends(get_admin_or_support_user)):
             )
         )
         db.commit()
-    return {"id": payout_id, "status": PayoutStatusEnum.approved, "approved_mmk": str(approved_sum)}
+    return {
+        "id": payout_id,
+        "status": PayoutStatusEnum.approved,
+        "approved_mmk": str(approved_sum),
+    }
 
 
 @router.post("/payouts/{payout_id}/mark-paid")
-def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
+def mark_paid(payout_id: str, admin=Depends(get_admin_user)):
     with get_db() as db:
         payout = db.get(Payout, payout_id)
         if not payout:
@@ -63,6 +100,15 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
         before = {"status": payout.status.value}
         payout.status = PayoutStatusEnum.paid
         after = {"status": payout.status.value}
+
+        items = db.query(PayoutItem).filter(PayoutItem.payout_id == payout_id).all()
+        commission_ids = [i.commission_id for i in items]
+        if commission_ids:
+            db.query(Commission).filter(Commission.id.in_(commission_ids)).update(
+                {Commission.status: CommissionStatusEnum.paid},
+                synchronize_session=False,
+            )
+
         db.add(
             OutboxEvent(
                 event_type="payout_paid",
@@ -87,10 +133,58 @@ def mark_paid(payout_id: str, admin=Depends(get_admin_or_support_user)):
     return {"id": payout_id, "status": PayoutStatusEnum.paid}
 
 
-@router.get("/payouts/export")
-def export_payouts(admin=Depends(get_admin_or_support_user)):
+@router.get("/payouts", response_model=List[PayoutSchema])
+def list_payouts(
+    partner_id: Optional[str] = None,
+    status: Optional[PayoutStatusEnum] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    admin=Depends(get_admin_or_support_user),
+):
     with get_db() as db:
-        payouts = db.execute(select(Payout)).scalars().all()
+        query = db.query(Payout)
+        if partner_id:
+            query = query.filter(Payout.partner_id == partner_id)
+        if status:
+            query = query.filter(Payout.status == status)
+        if start:
+            query = query.filter(Payout.created_at >= start)
+        if end:
+            query = query.filter(Payout.created_at <= end)
+        payouts = query.order_by(Payout.created_at.desc()).all()
+        return [PayoutSchema.model_validate(p, from_attributes=True) for p in payouts]
+
+
+@router.get("/payouts/{payout_id}", response_model=PayoutDetail)
+def get_payout_detail(payout_id: str, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        payout = db.get(Payout, payout_id)
+        if not payout:
+            raise HTTPException(status_code=404, detail="Payout not found")
+        items = (
+            db.query(PayoutItem)
+            .join(Commission, Commission.id == PayoutItem.commission_id)
+            .filter(PayoutItem.payout_id == payout_id)
+            .order_by(Commission.created_at.asc())
+            .all()
+        )
+        base = PayoutSchema.model_validate(payout, from_attributes=True)
+        return PayoutDetail(
+            **base.model_dump(),
+            items=[
+                PayoutItemSchema.model_validate(i, from_attributes=True) for i in items
+            ],
+        )
+
+
+@router.get("/payouts/export")
+def export_payouts(ids: Optional[str] = None, admin=Depends(get_admin_or_support_user)):
+    with get_db() as db:
+        query = db.query(Payout)
+        if ids:
+            id_list = ids.split(",")
+            query = query.filter(Payout.id.in_(id_list))
+        payouts = query.all()
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(
@@ -123,6 +217,32 @@ def export_payouts(admin=Depends(get_admin_or_support_user)):
     return Response(content=buf.getvalue(), media_type="text/csv")
 
 
+class ExportItemsForm(BaseModel):
+    ids: List[str]
+
+
+@router.post("/payouts/items/export")
+def export_payout_items(
+    form: ExportItemsForm, admin=Depends(get_admin_or_support_user)
+):
+    with get_db() as db:
+        items = db.query(PayoutItem).filter(PayoutItem.id.in_(form.ids)).all()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["id", "payout_id", "commission_id", "amount", "created_at"])
+    for item in items:
+        writer.writerow(
+            [
+                item.id,
+                item.payout_id,
+                item.commission_id,
+                item.amount,
+                item.created_at,
+            ]
+        )
+    return Response(content=buf.getvalue(), media_type="text/csv")
+
+
 @router.post("/payouts/import")
 async def import_payouts(file: UploadFile, admin=Depends(get_admin_or_support_user)):
     data = (await file.read()).decode()
@@ -132,10 +252,14 @@ async def import_payouts(file: UploadFile, admin=Depends(get_admin_or_support_us
         for row in reader:
             payout_id = row.get("id") or str(uuid.uuid4())
             existing = db.get(Payout, payout_id)
-            before = {
-                "status": existing.status.value,
-                "total_amount": str(existing.total_amount),
-            } if existing else None
+            before = (
+                {
+                    "status": existing.status.value,
+                    "total_amount": str(existing.total_amount),
+                }
+                if existing
+                else None
+            )
             payout = Payout(
                 id=payout_id,
                 partner_id=row["partner_id"],

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -292,3 +292,4 @@ def get_admin_or_support_user(user=Depends(get_current_user)):
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
     return user
+

--- a/src/lib/affiliate-admin/api.ts
+++ b/src/lib/affiliate-admin/api.ts
@@ -258,12 +258,61 @@ export const markPayoutPaid = async (
     return handle(res);
 };
 
-export const exportPayouts = async (
-    token: string
-): Promise<string> => {
-    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/export`, {
+export const listPayouts = async (
+    token: string,
+    params: {
+        partner_id?: string;
+        status?: string;
+        start?: number;
+        end?: number;
+    } = {}
+): Promise<Payout[]> => {
+    const query = new URLSearchParams();
+    if (params.partner_id) query.set('partner_id', params.partner_id);
+    if (params.status) query.set('status', params.status);
+    if (params.start) query.set('start', String(params.start));
+    if (params.end) query.set('end', String(params.end));
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts?${query.toString()}`, {
         method: 'GET',
         headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const getPayout = async (
+    token: string,
+    payoutId: string
+): Promise<PayoutDetail> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/${payoutId}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const exportPayouts = async (
+    token: string,
+    ids: string[] = []
+): Promise<string> => {
+    const query = ids.length ? `?ids=${ids.join(',')}` : '';
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/export${query}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    if (!res.ok) {
+        throw await res.json();
+    }
+    return res.text();
+};
+
+export const exportPayoutItems = async (
+    token: string,
+    ids: string[]
+): Promise<string> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/payouts/items/export`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify({ ids }),
     });
     if (!res.ok) {
         throw await res.json();

--- a/src/lib/affiliate-admin/types.ts
+++ b/src/lib/affiliate-admin/types.ts
@@ -78,6 +78,30 @@ export interface CommissionAdjustmentForm {
     reason?: string;
 }
 
+export interface PayoutItem {
+    id: string;
+    payout_id: string;
+    commission_id: string;
+    amount: DecimalString;
+    created_at: number;
+}
+
+export interface Payout {
+    id: string;
+    partner_id: string;
+    requested_amount: DecimalString;
+    total_amount: DecimalString;
+    fee_mmk: DecimalString;
+    status: 'pending' | 'approved' | 'paid' | 'rejected';
+    reference?: string;
+    approved_mmk?: DecimalString;
+    created_at: number;
+}
+
+export interface PayoutDetail extends Payout {
+    items: PayoutItem[];
+}
+
 export interface Link {
     id: string;
     partner_id: string;


### PR DESCRIPTION
## Summary
- add payout list and detail endpoints with FIFO commission order
- export selected payouts or items to CSV
- restrict mark-paid to admins and update related commissions

## Testing
- `pip install moto` *(fails: Could not find a version that satisfies the requirement moto)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'moto', 'test.util', 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_68a51070ae888333b07d7966d9aa33e1