### PR TITLE
feat(admin): add affiliate section skeleton

### DIFF
--- a/src/routes/(app)/admin/affiliate/+layout.svelte
+++ b/src/routes/(app)/admin/affiliate/+layout.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+        import { onMount, getContext } from 'svelte';
+        import { goto } from '$app/navigation';
+        import { page } from '$app/stores';
+        import { user } from '$lib/stores';
+
+        const i18n = getContext('i18n');
+
+        let loaded = false;
+
+        const routeLabels: Record<string, string> = {
+                applications: 'Applications',
+                partners: 'Partners',
+                links: 'Links',
+                coupons: 'Coupons',
+                commissions: 'Commissions',
+                payouts: 'Payouts',
+                fraud: 'Fraud',
+                reports: 'Reports',
+                settings: 'Settings',
+                audit: 'Audit',
+                'order-lookup': 'Order Lookup'
+        };
+
+        let segment = '';
+        $: segment = $page.url.pathname.split('/')[3] || '';
+        $: currentLabel = routeLabels[segment];
+
+        onMount(async () => {
+                if ($user?.role !== 'admin') {
+                        await goto('/');
+                }
+                loaded = true;
+        });
+</script>
+
+<svelte:head>
+        <title>{`${$i18n.t('Affiliate')} • ${$i18n.t('Admin Panel')}`}</title>
+</svelte:head>
+
+{#if loaded}
+        <div class="p-4 text-gray-800 dark:text-gray-200">
+                <nav class="text-sm mb-4 text-gray-500 dark:text-gray-400">
+                        <a href="/admin" class="hover:underline">{$i18n.t('Admin')}</a>
+                        <span class="mx-1">/</span>
+                        <a href="/admin/affiliate" class="hover:underline">{$i18n.t('Affiliate')}</a>
+                        {#if currentLabel}
+                                <span class="mx-1">/</span>
+                                <span>{$i18n.t(currentLabel)}</span>
+                        {/if}
+                </nav>
+                <slot />
+        </div>
+{/if}

--- a/src/routes/(app)/admin/affiliate/+layout.ts
+++ b/src/routes/(app)/admin/affiliate/+layout.ts
@@ -1,0 +1,10 @@
+import type { LayoutLoad } from './$types';
+import { getSessionUser } from '$lib/apis/auths';
+
+export const load: LayoutLoad = async () => {
+        const sessionUser = await getSessionUser(localStorage.token).catch(() => null);
+        return {
+                user: sessionUser,
+                roles: sessionUser ? [sessionUser.role] : []
+        };
+};

--- a/src/routes/(app)/admin/affiliate/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+        import { goto } from '$app/navigation';
+        import { onMount } from 'svelte';
+
+        onMount(() => {
+                goto('/admin/affiliate/applications');
+        });
+</script>

--- a/src/routes/(app)/admin/affiliate/applications/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/applications/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Applications')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/audit/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/audit/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Audit')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/commissions/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/commissions/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Commissions')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/coupons/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/coupons/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Coupons')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/fraud/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/fraud/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Fraud')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/links/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/links/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Links')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/order-lookup/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/order-lookup/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Order Lookup')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/partners/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/partners/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Partners')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/payouts/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/payouts/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Payouts')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/reports/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/reports/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Reports')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>

--- a/src/routes/(app)/admin/affiliate/settings/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/settings/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+        import { getContext } from 'svelte';
+        import { toast } from 'svelte-sonner';
+        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+        const i18n = getContext('i18n');
+
+        let showDialog = false;
+
+        const handleToast = () => {
+                toast.info($i18n.t('This is a placeholder'));
+        };
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+        <h1 class="text-2xl font-semibold">{$i18n.t('Settings')}</h1>
+        <div class="flex gap-2">
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={handleToast}
+                >{$i18n.t('Show Toast')}</button>
+                <button
+                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
+                        on:click={() => (showDialog = true)}
+                >{$i18n.t('Show Dialog')}</button>
+        </div>
+        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+</div>


### PR DESCRIPTION
## Summary
- add affiliate admin layout with RBAC guard and breadcrumbs
- load session user and roles for affiliate pages
- scaffold affiliate subsections (applications, partners, links, coupons, commissions, payouts, fraud, reports, settings, audit, order lookup) with placeholder pages

## Testing
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a510963904833397fc087bc522e48b