### PR TITLE
feat: add affiliate admin components

### DIFF
--- a/src/lib/affiliate-admin/components/CSVExportButton.svelte
+++ b/src/lib/affiliate-admin/components/CSVExportButton.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { toast } from 'svelte-sonner';
+  export let data: Record<string, any>[] = [];
+  export let filename: string = 'export.csv';
+
+  const exportCSV = () => {
+    if (!data || data.length === 0) {
+      toast.error('No data to export');
+      return;
+    }
+    const keys = Object.keys(data[0]);
+    const rows = data.map(row => keys.map(k => JSON.stringify(row[k] ?? '')).join(','));
+    const csvContent = [keys.join(','), ...rows].join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    toast.success('CSV downloaded');
+  };
+</script>
+
+<button type="button" on:click={exportCSV} class="px-3 py-2 rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-sm font-medium">
+  Export CSV
+</button>

--- a/src/lib/affiliate-admin/components/CardSkeleton.svelte
+++ b/src/lib/affiliate-admin/components/CardSkeleton.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let lines = 3;
+</script>
+
+<div class="p-4 bg-white dark:bg-gray-900 rounded-lg shadow animate-pulse space-y-2">
+  {#each Array(lines) as _}
+    <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded"></div>
+  {/each}
+</div>

--- a/src/lib/affiliate-admin/components/ConfirmDialog.svelte
+++ b/src/lib/affiliate-admin/components/ConfirmDialog.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import DOMPurify from 'dompurify';
+  import { onMount, onDestroy } from 'svelte';
+  import * as FocusTrap from 'focus-trap';
+  import { fade } from 'svelte/transition';
+  import { flyAndScale } from '$lib/utils/transitions';
+  import { marked } from 'marked';
+
+  export let title = '';
+  export let message = '';
+  export let cancelLabel = 'Cancel';
+  export let confirmLabel = 'Confirm';
+  export let onConfirm: () => void | Promise<void> = () => {};
+  export let show = false;
+
+  let modalElement: HTMLDivElement | null = null;
+  let mounted = false;
+  let focusTrap: FocusTrap.FocusTrap | null = null;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') show = false;
+    if (event.key === 'Enter') confirmHandler();
+  };
+
+  const confirmHandler = async () => {
+    show = false;
+    await onConfirm();
+  };
+
+  onMount(() => {
+    mounted = true;
+  });
+
+  $: if (mounted) {
+    if (show && modalElement) {
+      document.body.appendChild(modalElement);
+      focusTrap = FocusTrap.createFocusTrap(modalElement);
+      focusTrap.activate();
+      window.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    } else if (modalElement) {
+      focusTrap && focusTrap.deactivate();
+      window.removeEventListener('keydown', handleKeyDown);
+      if (document.body.contains(modalElement)) {
+        document.body.removeChild(modalElement);
+        document.body.style.overflow = 'unset';
+      }
+    }
+  }
+
+  onDestroy(() => {
+    if (focusTrap) focusTrap.deactivate();
+    if (modalElement && document.body.contains(modalElement)) {
+      document.body.removeChild(modalElement);
+    }
+    document.body.style.overflow = 'unset';
+  });
+</script>
+
+{#if show}
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  bind:this={modalElement}
+  class="fixed inset-0 bg-black/60 flex justify-center items-center z-50"
+  in:fade={{ duration: 10 }}
+  on:mousedown={() => (show = false)}
+>
+  <div
+    class="bg-gray-50 dark:bg-gray-950 rounded-2xl w-full max-w-md mx-2 shadow-3xl"
+    in:flyAndScale
+    on:mousedown|stopPropagation
+  >
+    <div class="px-6 py-6 flex flex-col">
+      <div class="text-lg font-semibold dark:text-gray-200 mb-2.5">{title || 'Confirm your action'}</div>
+      <div class="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        {@html DOMPurify.sanitize(marked.parse(message || 'This action cannot be undone. Do you wish to continue?'))}
+      </div>
+      <div class="flex justify-between gap-1.5">
+        <button
+          class="bg-gray-100 hover:bg-gray-200 text-gray-800 dark:bg-gray-850 dark:hover:bg-gray-800 dark:text-white font-medium w-full py-2.5 rounded-lg transition"
+          on:click={() => (show = false)}
+        >{cancelLabel}</button>
+        <button
+          class="bg-gray-900 hover:bg-gray-850 text-gray-100 dark:bg-gray-100 dark:hover:bg-white dark:text-gray-800 font-medium w-full py-2.5 rounded-lg transition"
+          on:click={confirmHandler}
+        >{confirmLabel}</button>
+      </div>
+    </div>
+  </div>
+</div>
+{/if}

--- a/src/lib/affiliate-admin/components/CopyField.svelte
+++ b/src/lib/affiliate-admin/components/CopyField.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { toast } from 'svelte-sonner';
+  export let value: string = '';
+  export let label: string = '';
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success('Copied to clipboard');
+    } catch (e) {
+      toast.error('Failed to copy');
+    }
+  };
+</script>
+
+<div class="w-full">
+  {#if label}
+    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</label>
+  {/if}
+  <div class="flex items-center gap-2">
+    <input class="flex-1 px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100" bind:value readonly />
+    <button type="button" on:click={copy} class="px-3 py-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-sm font-medium">Copy</button>
+  </div>
+</div>

--- a/src/lib/affiliate-admin/components/DataGrid.svelte
+++ b/src/lib/affiliate-admin/components/DataGrid.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  export interface Column {
+    key: string;
+    label: string;
+    class?: string;
+  }
+  export let columns: Column[] = [];
+  export let rows: any[] = [];
+</script>
+
+<table class="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+  <thead class="bg-gray-50 dark:bg-gray-900">
+    <tr>
+      {#each columns as column}
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider {column.class ?? ''}">
+          {column.label}
+        </th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody class="bg-white dark:bg-gray-950 divide-y divide-gray-200 dark:divide-gray-800">
+    {#if rows.length === 0}
+      <tr>
+        <td class="px-4 py-4 text-center text-sm text-gray-500 dark:text-gray-400" colspan={columns.length}>
+          <slot name="empty">No data</slot>
+        </td>
+      </tr>
+    {:else}
+      {#each rows as row}
+        <tr class="hover:bg-gray-50 dark:hover:bg-gray-900">
+          {#each columns as column}
+            <td class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">
+              <slot name={column.key} {row}>{row[column.key]}</slot>
+            </td>
+          {/each}
+        </tr>
+      {/each}
+    {/if}
+  </tbody>
+</table>

--- a/src/lib/affiliate-admin/components/DataGridSkeleton.svelte
+++ b/src/lib/affiliate-admin/components/DataGridSkeleton.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  export let columns = 3;
+  export let rows = 5;
+</script>
+
+<table class="min-w-full divide-y divide-gray-200 dark:divide-gray-800 animate-pulse">
+  <thead class="bg-gray-50 dark:bg-gray-900">
+    <tr>
+      {#each Array(columns) as _, i}
+        <th class="px-4 py-2">
+          <div class="h-3 w-1/2 bg-gray-200 dark:bg-gray-700 rounded"></div>
+        </th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody class="bg-white dark:bg-gray-950 divide-y divide-gray-200 dark:divide-gray-800">
+    {#each Array(rows) as _, r}
+      <tr>
+        {#each Array(columns) as _}
+          <td class="px-4 py-2">
+            <div class="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded"></div>
+          </td>
+        {/each}
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/lib/affiliate-admin/components/DateRangePicker.svelte
+++ b/src/lib/affiliate-admin/components/DateRangePicker.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  export let start: string = '';
+  export let end: string = '';
+  const dispatch = createEventDispatcher<{ change: { start: string; end: string } }>();
+
+  $: dispatch('change', { start, end });
+</script>
+
+<div class="flex items-center gap-2">
+  <input type="date" bind:value={start} class="px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100" />
+  <span class="text-gray-500 dark:text-gray-400">to</span>
+  <input type="date" bind:value={end} class="px-3 py-2 rounded border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100" />
+</div>

--- a/src/lib/affiliate-admin/components/DetailCard.svelte
+++ b/src/lib/affiliate-admin/components/DetailCard.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let title: string = '';
+  export let items: { label: string; value: any }[] = [];
+</script>
+
+<div class="rounded-lg bg-white dark:bg-gray-900 shadow p-4">
+  {#if title}
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">{title}</h3>
+  {/if}
+  <div class="space-y-2">
+    {#each items as item}
+      <div class="flex justify-between text-sm">
+        <span class="text-gray-500 dark:text-gray-400">{item.label}</span>
+        <span class="text-gray-900 dark:text-gray-100"><slot name={item.label} {item}>{item.value}</slot></span>
+      </div>
+    {/each}
+    <slot />
+  </div>
+</div>

--- a/src/lib/affiliate-admin/components/Drawer.svelte
+++ b/src/lib/affiliate-admin/components/Drawer.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { fade, fly } from 'svelte/transition';
+
+  export let show = false;
+  export let className = '';
+  export let onClose: () => void = () => {};
+
+  let modalElement: HTMLDivElement | null = null;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      show = false;
+    }
+  };
+
+  onMount(() => {
+    if (show && modalElement) {
+      document.body.appendChild(modalElement);
+      window.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+  });
+
+  $: if (!show && modalElement && document.body.contains(modalElement)) {
+    document.body.removeChild(modalElement);
+    window.removeEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'unset';
+    onClose();
+  } else if (show && modalElement && !document.body.contains(modalElement)) {
+    document.body.appendChild(modalElement);
+    window.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+  }
+
+  onDestroy(() => {
+    if (modalElement && document.body.contains(modalElement)) {
+      document.body.removeChild(modalElement);
+    }
+    window.removeEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'unset';
+  });
+</script>
+
+{#if show}
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<div
+  bind:this={modalElement}
+  class="fixed inset-0 bg-black/60 flex justify-end z-50"
+  in:fade={{ duration: 100 }}
+  on:mousedown={() => (show = false)}
+>
+  <div
+    class="w-full max-w-md h-full bg-white dark:bg-gray-900 overflow-y-auto {className}"
+    in:fly={{ x: 200, duration: 150 }}
+    on:mousedown|stopPropagation
+  >
+    <slot />
+  </div>
+</div>
+{/if}

--- a/src/lib/affiliate-admin/components/EmptyState.svelte
+++ b/src/lib/affiliate-admin/components/EmptyState.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let title: string = 'No data';
+  export let description: string = '';
+  export let icon: typeof import('svelte').SvelteComponent | null = null;
+</script>
+
+<div class="text-center py-10">
+  {#if icon}
+    <div class="mx-auto mb-4 text-gray-400"><svelte:component this={icon} /></div>
+  {/if}
+  <h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+  {#if description}
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+  {/if}
+  <slot />
+</div>

--- a/src/lib/affiliate-admin/components/KPIStatCard.svelte
+++ b/src/lib/affiliate-admin/components/KPIStatCard.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  export let title: string = '';
+  export let value: string | number = '';
+  export let icon: typeof import('svelte').SvelteComponent | null = null;
+  export let change: string = '';
+  export let changeType: 'increase' | 'decrease' | '' = '';
+</script>
+
+<div class="p-4 bg-white dark:bg-gray-900 rounded-lg shadow flex items-center">
+  {#if icon}
+    <span class="p-3 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 mr-4">
+      <svelte:component this={icon} />
+    </span>
+  {/if}
+  <div class="flex-1">
+    {#if title}
+      <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{title}</p>
+    {/if}
+    <div class="flex items-baseline">
+      <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
+      {#if change}
+        <span class="ml-2 text-xs font-medium {changeType === 'increase' ? 'text-green-600 dark:text-green-400' : changeType === 'decrease' ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}">{change}</span>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/lib/affiliate-admin/components/Money.svelte
+++ b/src/lib/affiliate-admin/components/Money.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let value: number = 0;
+  export let currency: string = 'USD';
+  export let minimumFractionDigits = 2;
+</script>
+
+<span class="font-medium text-gray-900 dark:text-gray-100">
+  {new Intl.NumberFormat(undefined, { style: 'currency', currency, minimumFractionDigits }).format(value)}
+</span>

--- a/src/lib/affiliate-admin/components/Pagination.svelte
+++ b/src/lib/affiliate-admin/components/Pagination.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { Pagination } from 'bits-ui';
+  import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
+  import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
+
+  export let page = 0;
+  export let count = 0;
+  export let perPage = 20;
+</script>
+
+<div class="flex justify-center">
+  <Pagination.Root bind:page {count} {perPage} let:pages>
+    <div class="my-2 flex items-center">
+      <Pagination.PrevButton class="mr-[25px] inline-flex size-8 items-center justify-center rounded-[9px] bg-transparent hover:bg-gray-50 dark:hover:bg-gray-850 active:scale-98 disabled:cursor-not-allowed disabled:text-gray-400 dark:disabled:text-gray-700 hover:disabled:bg-transparent dark:hover:disabled:bg-transparent">
+        <ChevronLeft className="size-4" strokeWidth="2" />
+      </Pagination.PrevButton>
+      <div class="flex items-center gap-2.5">
+        {#each pages as page (page.key)}
+          {#if page.type === 'ellipsis'}
+            <div class="text-sm font-medium text-foreground-alt">...</div>
+          {:else}
+            <Pagination.Page {page} class="inline-flex size-8 items-center justify-center rounded-[9px] bg-transparent hover:bg-gray-50 dark:hover:bg-gray-850 text-sm font-medium hover:bg-dark-10 active:scale-98 disabled:cursor-not-allowed disabled:opacity-50 hover:disabled:bg-transparent data-selected:bg-gray-50 data-selected:text-gray-700 data-selected:hover:bg-gray-100 dark:data-selected:bg-gray-850 dark:data-selected:text-gray-50 dark:data-selected:hover:bg-gray-800 transition">
+              {page.value}
+            </Pagination.Page>
+          {/if}
+        {/each}
+      </div>
+      <Pagination.NextButton class="ml-[25px]  inline-flex size-8 items-center justify-center rounded-[9px] bg-transparent hover:bg-gray-50 dark:hover:bg-gray-850 active:scale-98 disabled:cursor-not-allowed disabled:text-gray-400 dark:disabled:text-gray-700 hover:disabled:bg-transparent dark:hover:disabled:bg-transparent">
+        <ChevronRight className="size-4" strokeWidth="2" />
+      </Pagination.NextButton>
+    </div>
+  </Pagination.Root>
+</div>

--- a/src/lib/affiliate-admin/components/StatusBadge.svelte
+++ b/src/lib/affiliate-admin/components/StatusBadge.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let status: 'success' | 'warning' | 'error' | 'info' | 'default' = 'default';
+  export let label: string = '';
+
+  const classes = {
+    success: 'bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-300',
+    warning: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800/20 dark:text-yellow-300',
+    error: 'bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-300',
+    info: 'bg-blue-100 text-blue-800 dark:bg-blue-800/20 dark:text-blue-300',
+    default: 'bg-gray-100 text-gray-800 dark:bg-gray-800/20 dark:text-gray-300'
+  } as const;
+</script>
+
+<span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full {classes[status]}">{label}</span>

--- a/src/lib/affiliate-admin/components/index.ts
+++ b/src/lib/affiliate-admin/components/index.ts
@@ -1,0 +1,14 @@
+export { default as DataGrid } from './DataGrid.svelte';
+export { default as Drawer } from './Drawer.svelte';
+export { default as DetailCard } from './DetailCard.svelte';
+export { default as KPIStatCard } from './KPIStatCard.svelte';
+export { default as Money } from './Money.svelte';
+export { default as StatusBadge } from './StatusBadge.svelte';
+export { default as CopyField } from './CopyField.svelte';
+export { default as ConfirmDialog } from './ConfirmDialog.svelte';
+export { default as CSVExportButton } from './CSVExportButton.svelte';
+export { default as DateRangePicker } from './DateRangePicker.svelte';
+export { default as Pagination } from './Pagination.svelte';
+export { default as EmptyState } from './EmptyState.svelte';
+export { default as DataGridSkeleton } from './DataGridSkeleton.svelte';
+export { default as CardSkeleton } from './CardSkeleton.svelte';

--- a/src/lib/affiliate-admin/index.ts
+++ b/src/lib/affiliate-admin/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './types';
 export * from './stores';
+export * from './components';


### PR DESCRIPTION
## Summary
- add reusable affiliate admin components (DataGrid, Drawer, DetailCard, KPIStatCard, Money, StatusBadge, CopyField, ConfirmDialog, CSV export, DateRangePicker, Pagination, EmptyState, skeleton loaders)
- export all new components via index for easy use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:frontend` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf007f42883339ea5be638f7f5970