### PR TITLE
feat: restrict affiliate admin access

### DIFF
--- a/src/lib/affiliate-admin/types.ts
+++ b/src/lib/affiliate-admin/types.ts
@@ -2,10 +2,13 @@ export type DecimalString = string;
 
 export interface AuditLog {
     id: string;
+    actor_id: string;
+    resource: string;
     action: string;
-    severity: 'info' | 'warning' | 'critical';
-    details?: Record<string, any>;
-    created_at: number;
+    before?: Record<string, any> | null;
+    after?: Record<string, any> | null;
+    reason?: string | null;
+    timestamp: number;
 }
 
 export interface Partner {

--- a/src/routes/(app)/admin/affiliate/+layout.svelte
+++ b/src/routes/(app)/admin/affiliate/+layout.svelte
@@ -26,9 +26,12 @@
         $: segment = $page.url.pathname.split('/')[3] || '';
         $: currentLabel = routeLabels[segment];
 
+        const allowedRoles = ['admin', 'finance', 'support', 'partner-manager'];
+
         onMount(async () => {
-                if ($user?.role !== 'admin') {
-                        await goto('/');
+                if (!$user || !allowedRoles.includes($user.role)) {
+                        await goto('/403');
+                        return;
                 }
                 loaded = true;
         });


### PR DESCRIPTION
## Summary
- limit affiliate admin access to admin, finance, support, and partner-manager roles with 403 redirect for others
- revert backend to existing AuditLog system, removing AffiliateAudit model and bulk-operation flags

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util', 'moto', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aeead2f7e08333b6e4be22bb5c41f0