### PR TITLE
feat: add partners table

### DIFF
--- a/src/lib/affiliate-admin/api.ts
+++ b/src/lib/affiliate-admin/api.ts
@@ -12,6 +12,12 @@ import type {
     Link,
     LinkCreateForm,
     LinkUpdateForm,
+    Coupon,
+    Click,
+    Attribution,
+    Payout,
+    PayoutDetail,
+    PayoutItem,
     RollupRow,
     AffiliateSettings,
     AffiliateSettingsForm,
@@ -389,6 +395,47 @@ export const deleteLink = async (
         method: 'DELETE',
         headers: jsonHeaders(token),
     });
+    return handle(res);
+};
+
+// Coupons
+export const listCoupons = async (
+    token: string,
+    params: { partner_id?: string } = {}
+): Promise<Coupon[]> => {
+    const query = new URLSearchParams();
+    if (params.partner_id) query.set('partner_id', params.partner_id);
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/coupons?${query.toString()}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Clicks
+export const listClicks = async (
+    token: string,
+    partnerId: string
+): Promise<Click[]> => {
+    const res = await fetch(`${ADMIN_AFFILIATE_API_BASE_URL}/clicks?partner_id=${partnerId}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+// Attributions
+export const listAttributions = async (
+    token: string,
+    partnerId: string
+): Promise<Attribution[]> => {
+    const res = await fetch(
+        `${ADMIN_AFFILIATE_API_BASE_URL}/attributions?partner_id=${partnerId}`,
+        {
+            method: 'GET',
+            headers: jsonHeaders(token),
+        }
+    );
     return handle(res);
 };
 

--- a/src/lib/affiliate-admin/types.ts
+++ b/src/lib/affiliate-admin/types.ts
@@ -105,6 +105,33 @@ export interface PayoutDetail extends Payout {
     items: PayoutItem[];
 }
 
+export interface Coupon {
+    id: string;
+    partner_id: string;
+    code: string;
+    discount_percent?: number;
+    expires_at?: number;
+    active: boolean;
+    created_at: number;
+}
+
+export interface Click {
+    id: number;
+    partner_id: string;
+    link_id?: string;
+    coupon_id?: string;
+    user_agent?: string;
+    created_at: number;
+}
+
+export interface Attribution {
+    id: string;
+    click_id: number;
+    partner_id: string;
+    attr_via: string;
+    created_at: number;
+}
+
 export interface Link {
     id: string;
     partner_id: string;

--- a/src/routes/(app)/admin/affiliate/partners/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/partners/+page.svelte
@@ -1,28 +1,144 @@
 <script lang="ts">
-        import { getContext } from 'svelte';
-        import { toast } from 'svelte-sonner';
-        import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+  import { getContext, onMount } from 'svelte';
+  import { DataGrid, Drawer, ConfirmDialog, EmptyState, DataGridSkeleton } from '$lib/affiliate-admin/components';
+  import { searchPartners, getPartner, updatePartner, activatePartner, suspendPartner } from '$lib/affiliate-admin/api';
+  import type { Partner, PartnerUpdateForm } from '$lib/affiliate-admin/types';
+  import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 
-        const i18n = getContext('i18n');
+  const i18n = getContext('i18n');
 
-        let showDialog = false;
+  let loading = false;
+  let partners: Partner[] = [];
+  let search = '';
+  let gridApi: GridApi | null = null;
+  const gridOptions: GridOptions = {
+    domLayout: 'autoHeight',
+    onGridReady: (p) => (gridApi = p.api)
+  };
 
-        const handleToast = () => {
-                toast.info($i18n.t('This is a placeholder'));
-        };
+  onMount(async () => {
+    loading = true;
+    try {
+      partners = await searchPartners(localStorage.token);
+    } finally {
+      loading = false;
+    }
+  });
+
+  $: if (gridApi) {
+    gridApi.setGridOption('quickFilterText', search);
+  }
+
+  let showEdit = false;
+  let currentPartner: Partner | null = null;
+  let editForm: PartnerUpdateForm = { name: '', email: '' };
+
+  async function openEdit(partner: Partner) {
+    const detail = await getPartner(localStorage.token, partner.id);
+    currentPartner = partner;
+    editForm = { name: detail.name, email: detail.email };
+    showEdit = true;
+  }
+
+  async function submitEdit() {
+    if (!currentPartner) return;
+    const updated = await updatePartner(localStorage.token, currentPartner.id, editForm);
+    partners = partners.map((p) => (p.id === currentPartner!.id ? { ...p, ...updated } : p));
+    showEdit = false;
+  }
+
+  let showConfirm = false;
+  let confirmMessage = '';
+  let confirmAction: () => void | Promise<void> = async () => {};
+
+  function confirmStatus(partner: Partner) {
+    if (partner.status === 'active') {
+      confirmMessage = `${$i18n.t('Suspend')} ${partner.name}?`;
+      confirmAction = async () => {
+        await suspendPartner(localStorage.token, partner.id);
+        partners = partners.map((p) => (p.id === partner.id ? { ...p, status: 'suspended' } : p));
+      };
+    } else {
+      confirmMessage = `${$i18n.t('Activate')} ${partner.name}?`;
+      confirmAction = async () => {
+        await activatePartner(localStorage.token, partner.id);
+        partners = partners.map((p) => (p.id === partner.id ? { ...p, status: 'active' } : p));
+      };
+    }
+    showConfirm = true;
+  }
+
+  function actionCellRenderer(params: any) {
+    const eDiv = document.createElement('div');
+    const viewLink = document.createElement('a');
+    viewLink.textContent = 'View';
+    viewLink.href = `/admin/affiliate/partners/${params.data.id}`;
+    viewLink.className = 'text-blue-600 hover:underline mr-2';
+    eDiv.appendChild(viewLink);
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.className = 'text-blue-600 hover:underline mr-2';
+    editBtn.addEventListener('click', () => openEdit(params.data));
+    eDiv.appendChild(editBtn);
+
+    const statusBtn = document.createElement('button');
+    if (params.data.status === 'active') {
+      statusBtn.textContent = 'Suspend';
+      statusBtn.className = 'text-red-600 hover:underline';
+    } else {
+      statusBtn.textContent = 'Activate';
+      statusBtn.className = 'text-green-600 hover:underline';
+    }
+    statusBtn.addEventListener('click', () => confirmStatus(params.data));
+    eDiv.appendChild(statusBtn);
+    return eDiv;
+  }
+
+  const columnDefs: ColDef[] = [
+    { headerName: 'ID', field: 'id', sortable: true },
+    { headerName: 'Name', field: 'name', sortable: true },
+    { headerName: 'Email', field: 'email', sortable: true },
+    { headerName: 'Role', field: 'role' },
+    { headerName: 'Status', field: 'status' },
+    { headerName: 'Balance', field: 'balance' },
+    { headerName: 'Actions', cellRenderer: actionCellRenderer, sortable: false, filter: false }
+  ];
 </script>
 
 <div class="space-y-4 text-gray-800 dark:text-gray-200">
-        <h1 class="text-2xl font-semibold">{$i18n.t('Partners')}</h1>
-        <div class="flex gap-2">
-                <button
-                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
-                        on:click={handleToast}
-                >{$i18n.t('Show Toast')}</button>
-                <button
-                        class="px-3 py-1 rounded-md bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-200"
-                        on:click={() => (showDialog = true)}
-                >{$i18n.t('Show Dialog')}</button>
-        </div>
-        <ConfirmDialog bind:show={showDialog} title={$i18n.t('Example Dialog')} />
+  <h1 class="text-2xl font-semibold">{$i18n.t('Partners')}</h1>
+
+  <input
+    class="p-2 border rounded w-full md:w-1/3"
+    placeholder={$i18n.t('Search')}
+    bind:value={search}
+  />
+
+  {#if loading}
+    <DataGridSkeleton />
+  {:else if partners.length === 0}
+    <EmptyState title={$i18n.t('No partners')} />
+  {:else}
+    <DataGrid {columnDefs} rowData={partners} {gridOptions} />
+  {/if}
 </div>
+
+<Drawer bind:show={showEdit} onClose={() => (currentPartner = null)}>
+  <div class="p-4 space-y-4">
+    <h2 class="text-lg font-semibold">{$i18n.t('Edit Partner')}</h2>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Name')}</label>
+      <input class="w-full p-2 border rounded" bind:value={editForm.name} />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Email')}</label>
+      <input class="w-full p-2 border rounded" bind:value={editForm.email} />
+    </div>
+    <div class="flex justify-end gap-2">
+      <button class="px-3 py-1 rounded bg-gray-200" on:click={() => (showEdit = false)}>{$i18n.t('Cancel')}</button>
+      <button class="px-3 py-1 rounded bg-blue-600 text-white" on:click={submitEdit}>{$i18n.t('Save')}</button>
+    </div>
+  </div>
+</Drawer>
+
+<ConfirmDialog bind:show={showConfirm} title={$i18n.t('Confirm')} message={confirmMessage} onConfirm={confirmAction} />

--- a/src/routes/(app)/admin/affiliate/partners/[partnerId]/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/partners/[partnerId]/+page.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { getContext, onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { page } from '$app/stores';
+  import {
+    DataGrid,
+    DataGridSkeleton,
+    EmptyState
+  } from '$lib/affiliate-admin/components';
+  import {
+    getPartner,
+    listLinks,
+    listCoupons,
+    listClicks,
+    listAttributions,
+    listCommissions,
+    listPayouts,
+    getPayout
+  } from '$lib/affiliate-admin/api';
+  import type {
+    PartnerDetail,
+    Link,
+    Coupon,
+    Click,
+    Attribution,
+    Commission,
+    Payout,
+    PayoutItem
+  } from '$lib/affiliate-admin/types';
+  import type { ColDef, GridOptions } from 'ag-grid-community';
+
+  const i18n = getContext('i18n');
+
+  let partner: PartnerDetail | null = null;
+  let links: Link[] = [];
+  let coupons: Coupon[] = [];
+  let clicks: Click[] = [];
+  let attributions: Attribution[] = [];
+  let commissions: Commission[] = [];
+  let payouts: Payout[] = [];
+  let payoutItems: PayoutItem[] = [];
+  let loading = false;
+
+  const gridOptions: GridOptions = { domLayout: 'autoHeight' };
+
+  const linkCols: ColDef[] = [
+    { headerName: 'Code', field: 'code' },
+    { headerName: 'URL', field: 'url' },
+    { headerName: 'Active', field: 'active' }
+  ];
+
+  const couponCols: ColDef[] = [
+    { headerName: 'Code', field: 'code' },
+    { headerName: 'Discount', field: 'discount_percent' },
+    { headerName: 'Expires', field: 'expires_at' },
+    { headerName: 'Active', field: 'active' }
+  ];
+
+  const clickCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Link', field: 'link_id' },
+    { headerName: 'Coupon', field: 'coupon_id' },
+    { headerName: 'Created', field: 'created_at' }
+  ];
+
+  const attributionCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Click', field: 'click_id' },
+    { headerName: 'Via', field: 'attr_via' },
+    { headerName: 'Created', field: 'created_at' }
+  ];
+
+  const commissionCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Order', field: 'order_id' },
+    { headerName: 'Type', field: 'type' },
+    { headerName: 'Status', field: 'status' },
+    { headerName: 'Amount', field: 'amount' }
+  ];
+
+  const payoutCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Requested', field: 'requested_amount' },
+    { headerName: 'Total', field: 'total_amount' },
+    { headerName: 'Status', field: 'status' }
+  ];
+
+  const payoutItemCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Payout', field: 'payout_id' },
+    { headerName: 'Commission', field: 'commission_id' },
+    { headerName: 'Amount', field: 'amount' }
+  ];
+
+  onMount(async () => {
+    loading = true;
+    const token = localStorage.token;
+    const partnerId = get(page).params.partnerId;
+    try {
+      const [p, l, cpn, clk, attr, comm, pay] = await Promise.all([
+        getPartner(token, partnerId),
+        listLinks(token, { partner_id: partnerId }),
+        listCoupons(token, { partner_id: partnerId }),
+        listClicks(token, partnerId),
+        listAttributions(token, partnerId),
+        listCommissions(token, { partner_id: partnerId }),
+        listPayouts(token, { partner_id: partnerId })
+      ]);
+      partner = p;
+      links = l;
+      coupons = cpn;
+      clicks = clk;
+      attributions = attr;
+      commissions = comm;
+      payouts = pay;
+      const details = await Promise.all(pay.map((p) => getPayout(token, p.id)));
+      payoutItems = details.flatMap((d) => d.items);
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="space-y-6 text-gray-800 dark:text-gray-200">
+  {#if partner}
+    <div class="space-y-1">
+      <h1 class="text-2xl font-semibold">{partner.name}</h1>
+      <p>{partner.email}</p>
+      <p>{$i18n.t('Status')}: {partner.status}</p>
+    </div>
+  {/if}
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Links')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if links.length === 0}
+      <EmptyState title={$i18n.t('No links')} />
+    {:else}
+      <DataGrid columnDefs={linkCols} rowData={links} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Coupons')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if coupons.length === 0}
+      <EmptyState title={$i18n.t('No coupons')} />
+    {:else}
+      <DataGrid columnDefs={couponCols} rowData={coupons} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Clicks')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if clicks.length === 0}
+      <EmptyState title={$i18n.t('No clicks')} />
+    {:else}
+      <DataGrid columnDefs={clickCols} rowData={clicks} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Attributions')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if attributions.length === 0}
+      <EmptyState title={$i18n.t('No attributions')} />
+    {:else}
+      <DataGrid columnDefs={attributionCols} rowData={attributions} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Commissions')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if commissions.length === 0}
+      <EmptyState title={$i18n.t('No commissions')} />
+    {:else}
+      <DataGrid columnDefs={commissionCols} rowData={commissions} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Payouts')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if payouts.length === 0}
+      <EmptyState title={$i18n.t('No payouts')} />
+    {:else}
+      <DataGrid columnDefs={payoutCols} rowData={payouts} {gridOptions} />
+    {/if}
+  </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Payout Items')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if payoutItems.length === 0}
+      <EmptyState title={$i18n.t('No payout items')} />
+    {:else}
+      <DataGrid columnDefs={payoutItemCols} rowData={payoutItems} {gridOptions} />
+    {/if}
+  </section>
+</div>
+


### PR DESCRIPTION
## Summary
- replace partners placeholder with DataGrid listing
- add edit drawer and status toggle for partners
- add partner detail route to view links, coupons, clicks, attributions, commissions, payouts and payout items

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af8c2b89888333840af459743adaff