### PR TITLE
feat(admin): enhance partner detail management

### DIFF
--- a/backend/open_webui/routers/admin/affiliate/partners.py
+++ b/backend/open_webui/routers/admin/affiliate/partners.py
@@ -128,7 +128,6 @@ class PartnerUpdateForm(BaseModel):
     payout_details: Optional[dict] = None
     rates: Optional[dict] = None
     terms_version: Optional[str] = None
-    blocked_channels: Optional[List[str]] = None
 
 
 @router.put("/partners/{partner_id}", response_model=PartnerDetailSchema)
@@ -171,12 +170,6 @@ def update_partner(
             before["rates"] = profile.rates
             profile.rates = form.rates
             changes["rates"] = form.rates
-        if form.blocked_channels is not None:
-            info = user.info or {}
-            before["blocked_channels"] = info.get("blocked_channels")
-            info["blocked_channels"] = form.blocked_channels
-            user.info = info
-            changes["blocked_channels"] = form.blocked_channels
         if form.terms_version is not None:
             before["terms_version"] = profile.terms.get("version") if profile.terms else None
             profile.terms = {

--- a/src/lib/affiliate-admin/types.ts
+++ b/src/lib/affiliate-admin/types.ts
@@ -24,6 +24,7 @@ export interface PartnerDetail extends Partner {
     payout_method?: string;
     payout_details?: Record<string, any>;
     rates?: Record<string, any>;
+    terms_version?: string;
     audit_logs: AuditLog[];
 }
 
@@ -59,7 +60,6 @@ export interface PartnerUpdateForm {
     payout_details?: Record<string, any>;
     rates?: Record<string, any>;
     terms_version?: string;
-    blocked_channels?: string[];
 }
 
 export interface Commission {

--- a/src/routes/(app)/admin/affiliate/partners/[partnerId]/+page.svelte
+++ b/src/routes/(app)/admin/affiliate/partners/[partnerId]/+page.svelte
@@ -4,27 +4,30 @@
   import {
     DataGrid,
     DataGridSkeleton,
-    EmptyState
+    EmptyState,
+    ConfirmDialog
   } from '$lib/affiliate-admin/components';
+  import Modal from '$lib/components/common/Modal.svelte';
   import {
     getPartner,
     listLinks,
     listCoupons,
-    listClicks,
-    listAttributions,
     listCommissions,
     listPayouts,
-    getPayout
+    getPayout,
+    updatePartner,
+    activatePartner,
+    suspendPartner
   } from '$lib/affiliate-admin/api';
   import type {
     PartnerDetail,
+    PartnerUpdateForm,
     Link,
     Coupon,
-    Click,
-    Attribution,
     Commission,
     Payout,
-    PayoutItem
+    PayoutItem,
+    AuditLog
   } from '$lib/affiliate-admin/types';
   import type { ColDef, GridOptions } from 'ag-grid-community';
 
@@ -33,12 +36,27 @@
   let partner: PartnerDetail | null = null;
   let links: Link[] = [];
   let coupons: Coupon[] = [];
-  let clicks: Click[] = [];
-  let attributions: Attribution[] = [];
   let commissions: Commission[] = [];
   let payouts: Payout[] = [];
   let payoutItems: PayoutItem[] = [];
   let loading = false;
+
+  let showEdit = false;
+  let editForm: PartnerUpdateForm = {
+    name: '',
+    email: '',
+    status: 'active',
+    payout_method: '',
+    payout_details: {},
+    rates: {},
+    terms_version: ''
+  };
+  let payoutDetailsText = '';
+  let ratesText = '';
+
+  let showConfirm = false;
+  let confirmMessage = '';
+  let confirmAction: () => void | Promise<void> = async () => {};
 
   const gridOptions: GridOptions = { domLayout: 'autoHeight' };
 
@@ -53,20 +71,6 @@
     { headerName: 'Discount', field: 'discount_percent' },
     { headerName: 'Expires', field: 'expires_at' },
     { headerName: 'Active', field: 'active' }
-  ];
-
-  const clickCols: ColDef[] = [
-    { headerName: 'ID', field: 'id' },
-    { headerName: 'Link', field: 'link_id' },
-    { headerName: 'Coupon', field: 'coupon_id' },
-    { headerName: 'Created', field: 'created_at' }
-  ];
-
-  const attributionCols: ColDef[] = [
-    { headerName: 'ID', field: 'id' },
-    { headerName: 'Click', field: 'click_id' },
-    { headerName: 'Via', field: 'attr_via' },
-    { headerName: 'Created', field: 'created_at' }
   ];
 
   const commissionCols: ColDef[] = [
@@ -89,6 +93,14 @@
     { headerName: 'Payout', field: 'payout_id' },
     { headerName: 'Commission', field: 'commission_id' },
     { headerName: 'Amount', field: 'amount' }
+  ];
+
+  const auditLogCols: ColDef[] = [
+    { headerName: 'ID', field: 'id' },
+    { headerName: 'Actor', field: 'actor_id' },
+    { headerName: 'Action', field: 'action' },
+    { headerName: 'Resource', field: 'resource' },
+    { headerName: 'Timestamp', field: 'timestamp' }
   ];
 
   onMount(async () => {
@@ -117,14 +129,92 @@
       loading = false;
     }
   });
+
+  function openEdit() {
+    if (!partner) return;
+    editForm = {
+      name: partner.name,
+      email: partner.email,
+      status: partner.status,
+      payout_method: partner.payout_method,
+      payout_details: partner.payout_details,
+      rates: partner.rates,
+      terms_version: partner.terms_version
+    };
+    payoutDetailsText = JSON.stringify(partner.payout_details || {}, null, 2);
+    ratesText = JSON.stringify(partner.rates || {}, null, 2);
+    showEdit = true;
+  }
+
+  async function submitEdit() {
+    if (!partner) return;
+    try {
+      editForm.payout_details = payoutDetailsText ? JSON.parse(payoutDetailsText) : {};
+      editForm.rates = ratesText ? JSON.parse(ratesText) : {};
+    } catch (e) {
+      console.error('Invalid JSON', e);
+      return;
+    }
+    const updated = await updatePartner(localStorage.token, partner.id, editForm);
+    partner = updated;
+    showEdit = false;
+  }
+
+  function confirmStatus() {
+    if (!partner) return;
+    if (partner.status === 'active') {
+      confirmMessage = `${$i18n.t('Suspend')} ${partner.name}?`;
+      confirmAction = async () => {
+        await suspendPartner(localStorage.token, partner!.id);
+        partner = { ...partner!, status: 'suspended' };
+      };
+    } else {
+      confirmMessage = `${$i18n.t('Activate')} ${partner.name}?`;
+      confirmAction = async () => {
+        await activatePartner(localStorage.token, partner!.id);
+        partner = { ...partner!, status: 'active' };
+      };
+    }
+    showConfirm = true;
+  }
 </script>
 
 <div class="space-y-6 text-gray-800 dark:text-gray-200">
   {#if partner}
-    <div class="space-y-1">
-      <h1 class="text-2xl font-semibold">{partner.name}</h1>
-      <p>{partner.email}</p>
+    <div class="space-y-2">
+      <div class="flex justify-between items-start">
+        <div>
+          <h1 class="text-2xl font-semibold">{partner.name}</h1>
+          <p>{partner.email}</p>
+        </div>
+        <div class="flex gap-2">
+          <button class="px-3 py-1 rounded bg-blue-600 text-white" on:click={openEdit}>
+            {$i18n.t('Edit')}
+          </button>
+          {#if partner.status === 'active'}
+            <button class="px-3 py-1 rounded bg-red-600 text-white" on:click={confirmStatus}>
+              {$i18n.t('Suspend')}
+            </button>
+          {:else}
+            <button class="px-3 py-1 rounded bg-green-600 text-white" on:click={confirmStatus}>
+              {$i18n.t('Activate')}
+            </button>
+          {/if}
+        </div>
+      </div>
+      <p>{$i18n.t('Role')}: {partner.role}</p>
       <p>{$i18n.t('Status')}: {partner.status}</p>
+      <p>{$i18n.t('Balance')}: {partner.balance}</p>
+      <p>{$i18n.t('Payout Method')}: {partner.payout_method}</p>
+      <p>{$i18n.t('Terms Version')}: {partner.terms_version}</p>
+      <div>
+        <p class="font-semibold">{$i18n.t('Payout Details')}</p>
+        <pre class="bg-gray-100 dark:bg-gray-900 p-2 rounded overflow-x-auto">{JSON.stringify(partner.payout_details, null, 2)}</pre>
+      </div>
+      <div>
+        <p class="font-semibold">{$i18n.t('Rates')}</p>
+        <pre class="bg-gray-100 dark:bg-gray-900 p-2 rounded overflow-x-auto">{JSON.stringify(partner.rates, null, 2)}</pre>
+      </div>
     </div>
   {/if}
 
@@ -147,28 +237,6 @@
       <EmptyState title={$i18n.t('No coupons')} />
     {:else}
       <DataGrid columnDefs={couponCols} rowData={coupons} {gridOptions} />
-    {/if}
-  </section>
-
-  <section>
-    <h2 class="text-lg font-semibold">{$i18n.t('Clicks')}</h2>
-    {#if loading}
-      <DataGridSkeleton />
-    {:else if clicks.length === 0}
-      <EmptyState title={$i18n.t('No clicks')} />
-    {:else}
-      <DataGrid columnDefs={clickCols} rowData={clicks} {gridOptions} />
-    {/if}
-  </section>
-
-  <section>
-    <h2 class="text-lg font-semibold">{$i18n.t('Attributions')}</h2>
-    {#if loading}
-      <DataGridSkeleton />
-    {:else if attributions.length === 0}
-      <EmptyState title={$i18n.t('No attributions')} />
-    {:else}
-      <DataGrid columnDefs={attributionCols} rowData={attributions} {gridOptions} />
     {/if}
   </section>
 
@@ -204,5 +272,60 @@
       <DataGrid columnDefs={payoutItemCols} rowData={payoutItems} {gridOptions} />
     {/if}
   </section>
+
+  <section>
+    <h2 class="text-lg font-semibold">{$i18n.t('Audit Logs')}</h2>
+    {#if loading}
+      <DataGridSkeleton />
+    {:else if !partner || partner.audit_logs.length === 0}
+      <EmptyState title={$i18n.t('No audit logs')} />
+    {:else}
+      <DataGrid columnDefs={auditLogCols} rowData={partner.audit_logs} {gridOptions} />
+    {/if}
+  </section>
 </div>
+
+<Modal bind:show={showEdit} onClose={() => (showEdit = false)}>
+  <div class="p-4 space-y-4 text-gray-800 dark:text-gray-200">
+    <h2 class="text-lg font-semibold">{$i18n.t('Edit Partner')}</h2>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Name')}</label>
+      <input class="w-full p-2 border rounded bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={editForm.name} />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Email')}</label>
+      <input class="w-full p-2 border rounded bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={editForm.email} />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Status')}</label>
+      <select class="w-full p-2 border rounded bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={editForm.status}>
+        <option value="active">{$i18n.t('Active')}</option>
+        <option value="inactive">{$i18n.t('Inactive')}</option>
+        <option value="suspended">{$i18n.t('Suspended')}</option>
+      </select>
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Payout Method')}</label>
+      <input class="w-full p-2 border rounded bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={editForm.payout_method} />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Terms Version')}</label>
+      <input class="w-full p-2 border rounded bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={editForm.terms_version} />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Payout Details')}</label>
+      <textarea class="w-full p-2 border rounded font-mono text-sm h-24 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={payoutDetailsText}></textarea>
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm">{$i18n.t('Rates')}</label>
+      <textarea class="w-full p-2 border rounded font-mono text-sm h-24 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-700" bind:value={ratesText}></textarea>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button class="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200" on:click={() => (showEdit = false)}>{$i18n.t('Cancel')}</button>
+      <button class="px-3 py-1 rounded bg-blue-600 text-white" on:click={submitEdit}>{$i18n.t('Save')}</button>
+    </div>
+  </div>
+</Modal>
+
+<ConfirmDialog bind:show={showConfirm} title={$i18n.t('Confirm')} message={confirmMessage} onConfirm={confirmAction} />
 


### PR DESCRIPTION
## Summary
- drop blocked channel support from partner APIs and UI
- style partner edit modal for visibility in light and dark modes
- retain suspend/activate controls for partner accounts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config; svelte-kit and pylint not found)*
- `npm run format` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_68b1ca292fb483339ce624e6a3b4a4f5