### PR TITLE
feat: add plan and quota policy APIs

### DIFF
--- a/src/lib/affiliate-admin/api.ts
+++ b/src/lib/affiliate-admin/api.ts
@@ -1,4 +1,5 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
+import { handle, jsonHeaders } from '$lib/utils/api-helper';
 import type {
     Application,
     ApplicationApproveForm,
@@ -24,18 +25,6 @@ import type {
 } from './types';
 
 const ADMIN_AFFILIATE_API_BASE_URL = `${WEBUI_API_BASE_URL}/admin/affiliate`;
-
-const jsonHeaders = (token: string) => ({
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${token}`,
-});
-
-const handle = async (res: Response) => {
-    if (!res.ok) {
-        throw await res.json();
-    }
-    return res.json();
-};
 
 // Applications
 export const listApplications = async (

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -5,6 +5,9 @@ import { getOpenAIModelsDirect } from './openai';
 import { parse } from 'yaml';
 import { toast } from 'svelte-sonner';
 
+export * from './plans';
+export * from './quota-policies';
+
 export const getModels = async (
 	token: string = '',
 	connections: object | null = null,

--- a/src/lib/apis/plans.ts
+++ b/src/lib/apis/plans.ts
@@ -1,0 +1,47 @@
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+import { handle, jsonHeaders } from '$lib/utils/api-helper';
+
+export const createPlan = async (token: string, plan: object) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/plans`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(plan),
+    });
+    return handle(res);
+};
+
+export const getPlans = async (token: string = '') => {
+    const headers = token ? jsonHeaders(token) : undefined;
+    const res = await fetch(`${WEBUI_API_BASE_URL}/plans`, {
+        method: 'GET',
+        headers,
+    });
+    return handle(res);
+};
+
+export const getPlanById = async (token: string = '', planId: string) => {
+    const headers = token ? jsonHeaders(token) : undefined;
+    const res = await fetch(`${WEBUI_API_BASE_URL}/plans/${planId}`, {
+        method: 'GET',
+        headers,
+    });
+    return handle(res);
+};
+
+export const updatePlan = async (token: string, planId: string, plan: object) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/plans/${planId}`, {
+        method: 'PUT',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(plan),
+    });
+    return handle(res);
+};
+
+export const deletePlan = async (token: string, planId: string) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/plans/${planId}`, {
+        method: 'DELETE',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+

--- a/src/lib/apis/quota-policies.ts
+++ b/src/lib/apis/quota-policies.ts
@@ -1,0 +1,60 @@
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+import { handle, jsonHeaders } from '$lib/utils/api-helper';
+
+export const createQuotaPolicy = async (token: string, policy: object) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/quota_policy`, {
+        method: 'POST',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(policy),
+    });
+    return handle(res);
+};
+
+export const getQuotaPolicyById = async (token: string, policyId: string) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/quota_policy/${policyId}`, {
+        method: 'GET',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+
+export const getQuotaPolicies = async (
+    token: string,
+    userId?: string,
+    planId?: string,
+) => {
+    const params = new URLSearchParams();
+    if (userId) params.append('user_id', userId);
+    if (planId) params.append('plan_id', planId);
+    const query = params.toString();
+    const res = await fetch(
+        `${WEBUI_API_BASE_URL}/quota_policy${query ? `?${query}` : ''}`,
+        {
+            method: 'GET',
+            headers: jsonHeaders(token),
+        },
+    );
+    return handle(res);
+};
+
+export const updateQuotaPolicy = async (
+    token: string,
+    policyId: string,
+    policy: object,
+) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/quota_policy/${policyId}`, {
+        method: 'PUT',
+        headers: jsonHeaders(token),
+        body: JSON.stringify(policy),
+    });
+    return handle(res);
+};
+
+export const deleteQuotaPolicy = async (token: string, policyId: string) => {
+    const res = await fetch(`${WEBUI_API_BASE_URL}/quota_policy/${policyId}`, {
+        method: 'DELETE',
+        headers: jsonHeaders(token),
+    });
+    return handle(res);
+};
+

--- a/src/lib/utils/api-helper.ts
+++ b/src/lib/utils/api-helper.ts
@@ -1,0 +1,12 @@
+export const jsonHeaders = (token: string) => ({
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+});
+
+export const handle = async (res: Response) => {
+    if (!res.ok) {
+        throw await res.json();
+    }
+    return res.json();
+};
+


### PR DESCRIPTION
## Summary
- add frontend CRUD wrappers for plans and quota policies
- centralize shared fetch helpers for consistent API calls
- re-export plans and quota policy APIs for app-wide usage

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30d5ad890833399ca5e2b6cb77507