### PR TITLE
feat(types): add plan and quota policy interfaces

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,3 +13,6 @@ export enum TTS_RESPONSE_SPLIT {
 	PARAGRAPHS = 'paragraphs',
 	NONE = 'none'
 }
+
+export type { Plan, PlanType } from './plans';
+export type { QuotaPolicy, Window } from './quota-policy';

--- a/src/lib/types/plans.ts
+++ b/src/lib/types/plans.ts
@@ -1,0 +1,14 @@
+export type PlanType = 'subscription' | 'package' | 'topup' | 'custom';
+
+export interface Plan {
+    id: string;
+    name: string;
+    description?: string;
+    price: number;
+    credits: number;
+    plan_type: PlanType;
+    features?: Record<string, unknown>;
+    is_active: boolean;
+    created_at: number;
+    updated_at: number;
+}

--- a/src/lib/types/quota-policy.ts
+++ b/src/lib/types/quota-policy.ts
@@ -1,0 +1,12 @@
+export type Window = '3h' | '12h' | 'day' | 'week' | 'month';
+
+export interface QuotaPolicy {
+    id: string;
+    user_id?: string;
+    plan_id?: string;
+    resource_pattern: string;
+    limit: number;
+    window: Window;
+    effective_from: number;
+    expires_at?: number;
+}


### PR DESCRIPTION
## Summary
- add Plan interface and PlanType to represent backend PlanModel
- add QuotaPolicy and Window types mirroring backend model
- export new types for reuse

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:types` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b311f578ec8333a93a57670e2fa435