### PR TITLE
feat: add plan admin components

### DIFF
--- a/src/lib/components/admin/Plans/PlanList.svelte
+++ b/src/lib/components/admin/Plans/PlanList.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { DataGrid } from '$lib/affiliate-admin/components';
+  import type { ColDef } from 'ag-grid-community';
+  import PlanModal from './PlanModal.svelte';
+  import { getPlans, deletePlan } from '$lib/apis/plans';
+  import type { Plan } from '$lib/types/plans';
+  import { toast } from 'svelte-sonner';
+
+  let plans: Plan[] = [];
+  let loading = false;
+  let showModal = false;
+  let currentPlan: Plan | null = null;
+
+  onMount(async () => {
+    await loadPlans();
+  });
+
+  async function loadPlans() {
+    loading = true;
+    try {
+      plans = await getPlans(localStorage.token);
+    } catch (e) {
+      toast.error(`${e}`);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function openCreate() {
+    currentPlan = null;
+    showModal = true;
+  }
+
+  function openEdit(plan: Plan) {
+    currentPlan = plan;
+    showModal = true;
+  }
+
+  async function handleDelete(plan: Plan) {
+    if (!confirm('Delete plan?')) return;
+    try {
+      await deletePlan(localStorage.token, plan.id);
+      plans = plans.filter((p) => p.id !== plan.id);
+    } catch (e) {
+      toast.error(`${e}`);
+    }
+  }
+
+  function actionCellRenderer(params: any) {
+    const eDiv = document.createElement('div');
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.className = 'text-blue-600 hover:underline mr-2';
+    editBtn.addEventListener('click', () => openEdit(params.data));
+    eDiv.appendChild(editBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.className = 'text-red-600 hover:underline';
+    delBtn.addEventListener('click', () => handleDelete(params.data));
+    eDiv.appendChild(delBtn);
+
+    return eDiv;
+  }
+
+  function handleSaved(event: CustomEvent<Plan>) {
+    const saved = event.detail;
+    const idx = plans.findIndex((p) => p.id === saved.id);
+    if (idx >= 0) {
+      plans[idx] = saved;
+      plans = [...plans];
+    } else {
+      plans = [...plans, saved];
+    }
+  }
+
+  const columnDefs: ColDef[] = [
+    { headerName: 'ID', field: 'id', sortable: true },
+    { headerName: 'Name', field: 'name', sortable: true },
+    { headerName: 'Type', field: 'plan_type', sortable: true },
+    { headerName: 'Price', field: 'price', sortable: true },
+    { headerName: 'Credits', field: 'credits', sortable: true },
+    { headerName: 'Active', field: 'is_active', sortable: true },
+    { headerName: 'Actions', cellRenderer: actionCellRenderer, sortable: false, filter: false }
+  ];
+</script>
+
+<div class="space-y-4 text-gray-800 dark:text-gray-200">
+  <div class="flex justify-between items-center">
+    <h2 class="text-xl font-semibold">Plans</h2>
+    <button class="px-3 py-1 rounded bg-blue-600 text-white" on:click={openCreate}>Add Plan</button>
+  </div>
+
+  {#if loading}
+    <p>Loading...</p>
+  {:else if plans.length === 0}
+    <p>No plans found.</p>
+  {:else}
+    <DataGrid {columnDefs} rowData={plans} />
+  {/if}
+</div>
+
+<PlanModal bind:show={showModal} plan={currentPlan} on:saved={handleSaved} />
+

--- a/src/lib/components/admin/Plans/PlanModal.svelte
+++ b/src/lib/components/admin/Plans/PlanModal.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import Modal from '$lib/components/common/Modal.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import { createPlan, updatePlan } from '$lib/apis/plans';
+  import type { Plan, PlanType } from '$lib/types/plans';
+  import { toast } from 'svelte-sonner';
+
+  export let show = false;
+  export let plan: Plan | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  const defaultForm: Plan = {
+    id: '',
+    name: '',
+    description: '',
+    price: 0,
+    credits: 0,
+    plan_type: 'subscription' as PlanType,
+    features: {},
+    is_active: true,
+    created_at: 0,
+    updated_at: 0
+  };
+
+  let form: Plan = { ...defaultForm };
+
+  $: if (plan) {
+    form = { ...plan };
+  } else {
+    form = { ...defaultForm };
+  }
+
+  async function save() {
+    try {
+      let saved: Plan;
+      if (plan) {
+        saved = await updatePlan(localStorage.token, plan.id, {
+          name: form.name,
+          description: form.description,
+          price: form.price,
+          credits: form.credits,
+          plan_type: form.plan_type,
+          features: form.features,
+          is_active: form.is_active
+        });
+      } else {
+        saved = await createPlan(localStorage.token, {
+          name: form.name,
+          description: form.description,
+          price: form.price,
+          credits: form.credits,
+          plan_type: form.plan_type,
+          features: form.features,
+          is_active: form.is_active
+        });
+      }
+      dispatch('saved', saved);
+      show = false;
+    } catch (e) {
+      toast.error(`${e}`);
+    }
+  }
+</script>
+
+<Modal bind:show>
+  <div class="p-4 space-y-4 text-gray-900 dark:text-gray-100">
+    <h2 class="text-lg font-semibold">{plan ? 'Edit Plan' : 'Add Plan'}</h2>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Name</label>
+      <input
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.name}
+      />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Description</label>
+      <textarea
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.description}
+      ></textarea>
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Price</label>
+      <input
+        type="number"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.price}
+      />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Credits</label>
+      <input
+        type="number"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.credits}
+      />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Plan Type</label>
+      <select
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.plan_type}
+      >
+        <option value="subscription">subscription</option>
+        <option value="package">package</option>
+        <option value="topup">topup</option>
+        <option value="custom">custom</option>
+      </select>
+    </div>
+    <div class="space-y-2">
+      <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input type="checkbox" bind:checked={form.is_active} />
+        Active
+      </label>
+    </div>
+    <div class="flex justify-end gap-2 pt-2">
+      <button
+        class="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+        on:click={() => (show = false)}
+      >
+        Cancel
+      </button>
+      <button
+        class="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white"
+        on:click={save}
+      >
+        Save
+      </button>
+    </div>
+  </div>
+</Modal>
+

--- a/src/lib/components/admin/Plans/index.ts
+++ b/src/lib/components/admin/Plans/index.ts
@@ -1,0 +1,2 @@
+export { default as PlanList } from './PlanList.svelte';
+export { default as PlanModal } from './PlanModal.svelte';


### PR DESCRIPTION
## Summary
- add PlanModal for creating and editing plans with light and dark styling
- add PlanList powered by DataGrid with CRUD actions
- export new plan components

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*
- `npm run lint:types` *(fails: svelte-kit not found)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31a2493a883338755d1f7d246c7bc