### PR TITLE
feat: add admin quota policy components

### DIFF
--- a/src/lib/components/admin/QuotaPolicies/QuotaPolicyList.svelte
+++ b/src/lib/components/admin/QuotaPolicies/QuotaPolicyList.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { DataGrid } from '$lib/affiliate-admin/components';
+  import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+  import QuotaPolicyModal from './QuotaPolicyModal.svelte';
+  import { getQuotaPolicies, deleteQuotaPolicy } from '$lib/apis/quota-policies';
+  import { getUserById } from '$lib/apis/users';
+  import { getPlans } from '$lib/apis/plans';
+  import type { QuotaPolicy } from '$lib/types';
+  import type { Plan } from '$lib/types/plans';
+  import { toast } from 'svelte-sonner';
+
+  let policies: any[] = [];
+  let plans: Plan[] = [];
+  let loading = false;
+  let showModal = false;
+  let currentPolicy: QuotaPolicy | null = null;
+  let search = '';
+  let gridApi: GridApi | null = null;
+  const gridOptions: GridOptions = {
+    onGridReady: (p) => (gridApi = p.api)
+  };
+
+  $: if (gridApi) {
+    gridApi.setGridOption('quickFilterText', search);
+  }
+
+  onMount(async () => {
+    plans = await getPlans(localStorage.token).catch(() => []);
+    await loadPolicies();
+  });
+
+  async function loadPolicies() {
+    loading = true;
+    try {
+      const raw: QuotaPolicy[] = await getQuotaPolicies(localStorage.token);
+      policies = await Promise.all(
+        raw.map(async (p) => {
+          let user_email = '';
+          if (p.user_id) {
+            try {
+              const user = await getUserById(localStorage.token, p.user_id);
+              user_email = user.email;
+            } catch (e) {
+              console.error(e);
+            }
+          }
+          const plan = plans.find((pl) => pl.id === p.plan_id);
+          return { ...p, user_email, plan_name: plan ? plan.name : '' };
+        })
+      );
+    } catch (e) {
+      toast.error(`${e}`);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function openCreate() {
+    currentPolicy = null;
+    showModal = true;
+  }
+
+  function openEdit(policy: QuotaPolicy) {
+    currentPolicy = policy;
+    showModal = true;
+  }
+
+  async function handleDelete(policy: QuotaPolicy) {
+    if (!confirm('Delete policy?')) return;
+    try {
+      await deleteQuotaPolicy(localStorage.token, policy.id);
+      policies = policies.filter((p) => p.id !== policy.id);
+    } catch (e) {
+      toast.error(`${e}`);
+    }
+  }
+
+  function actionCellRenderer(params: any) {
+    const eDiv = document.createElement('div');
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.className = 'text-blue-600 hover:underline mr-2';
+    editBtn.addEventListener('click', () => openEdit(params.data));
+    eDiv.appendChild(editBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.className = 'text-red-600 hover:underline';
+    delBtn.addEventListener('click', () => handleDelete(params.data));
+    eDiv.appendChild(delBtn);
+
+    return eDiv;
+  }
+
+  async function handleSaved(event: CustomEvent<QuotaPolicy>) {
+    const saved = event.detail;
+    const plan = plans.find((pl) => pl.id === saved.plan_id);
+    let user_email = '';
+    if (saved.user_id) {
+      try {
+        const user = await getUserById(localStorage.token, saved.user_id);
+        user_email = user.email;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    const enriched = { ...saved, user_email, plan_name: plan ? plan.name : '' };
+    const idx = policies.findIndex((p) => p.id === saved.id);
+    if (idx >= 0) {
+      policies[idx] = enriched;
+      policies = [...policies];
+    } else {
+      policies = [...policies, enriched];
+    }
+  }
+
+  const columnDefs: ColDef[] = [
+    { headerName: 'ID', field: 'id', sortable: true },
+    { headerName: 'User Email', field: 'user_email', sortable: true },
+    { headerName: 'User ID', field: 'user_id', sortable: true },
+    { headerName: 'Plan Name', field: 'plan_name', sortable: true },
+    { headerName: 'Plan ID', field: 'plan_id', sortable: true },
+    { headerName: 'Resource', field: 'resource_pattern', sortable: true },
+    { headerName: 'Limit', field: 'limit', sortable: true },
+    { headerName: 'Window', field: 'window', sortable: true },
+    {
+      headerName: 'Effective From',
+      field: 'effective_from',
+      valueFormatter: ({ value }) => (value ? new Date(value * 1000).toLocaleString() : ''),
+      sortable: true
+    },
+    {
+      headerName: 'Expires At',
+      field: 'expires_at',
+      valueFormatter: ({ value }) => (value ? new Date(value * 1000).toLocaleString() : ''),
+      sortable: true
+    },
+    { headerName: 'Actions', cellRenderer: actionCellRenderer, sortable: false, filter: false }
+  ];
+</script>
+
+  <div class="space-y-4 text-gray-800 dark:text-gray-200">
+    <div class="flex justify-between items-center">
+      <h2 class="text-xl font-semibold">Quota Policies</h2>
+      <button class="px-3 py-1 rounded bg-blue-600 text-white" on:click={openCreate}>
+        Add Quota Policy
+      </button>
+    </div>
+
+    <input
+      class="p-2 border rounded w-full md:w-1/3"
+      placeholder="Search"
+      bind:value={search}
+    />
+
+    {#if loading}
+      <p>Loading...</p>
+    {:else if policies.length === 0}
+      <p>No quota policies found.</p>
+    {:else}
+      <DataGrid {columnDefs} rowData={policies} {gridOptions} />
+    {/if}
+  </div>
+
+<QuotaPolicyModal bind:show={showModal} policy={currentPolicy} on:saved={handleSaved} {plans} />

--- a/src/lib/components/admin/QuotaPolicies/QuotaPolicyModal.svelte
+++ b/src/lib/components/admin/QuotaPolicies/QuotaPolicyModal.svelte
@@ -1,0 +1,290 @@
+<script lang="ts">
+  import Modal from '$lib/components/common/Modal.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import { createQuotaPolicy, updateQuotaPolicy } from '$lib/apis/quota-policies';
+  import { getUsers, getUserById } from '$lib/apis/users';
+  import { models } from '$lib/stores';
+  import type { QuotaPolicy } from '$lib/types';
+  import type { Plan } from '$lib/types/plans';
+  import { toast } from 'svelte-sonner';
+  import Selector from '$lib/components/common/Selector.svelte';
+  import Search from '$lib/components/icons/Search.svelte';
+  import dayjs from 'dayjs';
+
+  export let show = false;
+  export let policy: QuotaPolicy | null = null;
+  export let plans: Plan[] = [];
+
+  const dispatch = createEventDispatcher();
+
+  const defaultForm: QuotaPolicy = {
+    id: '',
+    user_id: undefined,
+    plan_id: undefined,
+    resource_pattern: '',
+    limit: 0,
+    window: 'day',
+    effective_from: dayjs().unix(),
+    expires_at: undefined
+  };
+
+  let form: QuotaPolicy = { ...defaultForm };
+  let userInput = '';
+  let bulkMode = false;
+  let selectedModels: string[] = [];
+
+  let resourceType: 'model' | 'upload' | 'image' = 'model';
+  let modelValue = '*';
+  let uploadValue = '';
+  let imageValue = '';
+  let modelSearch = '';
+
+  $: modelItems = [{ value: '*', label: '*' }, ...$models.map((m) => ({ value: m.id, label: `${m.name} (${m.id})` }))];
+  $: filteredModelItems = modelSearch
+    ? modelItems.filter((i) => i.label.toLowerCase().includes(modelSearch.toLowerCase()))
+    : modelItems;
+  $: if (selectedModels.includes('*')) {
+    selectedModels = ['*'];
+  }
+
+  $: if (policy) {
+    form = { ...policy };
+    userInput = policy.user_id ?? '';
+    const [type, value] = (policy.resource_pattern || '').split(':');
+    resourceType = (type as any) || 'model';
+    if (resourceType === 'model') {
+      modelValue = value || '*';
+    } else if (resourceType === 'upload') {
+      uploadValue = value || '';
+    } else if (resourceType === 'image') {
+      imageValue = value || '';
+    }
+    bulkMode = false;
+    selectedModels = [];
+  } else {
+    form = { ...defaultForm };
+    userInput = '';
+    resourceType = 'model';
+    modelValue = '*';
+    uploadValue = '';
+    imageValue = '';
+    bulkMode = false;
+    selectedModels = [];
+  }
+
+  async function save() {
+    try {
+      let user_id = form.user_id;
+      if (userInput) {
+        if (userInput.includes('@')) {
+          const res = await getUsers(localStorage.token, userInput).catch(() => null);
+          if (res && res.users && res.users.length > 0) {
+            user_id = res.users[0].id;
+          } else {
+            throw 'User not found';
+          }
+        } else {
+          const u = await getUserById(localStorage.token, userInput);
+          user_id = u.id;
+        }
+      }
+      const basePayload = {
+        user_id,
+        plan_id: form.plan_id,
+        limit: form.limit,
+        window: form.window,
+        effective_from: form.effective_from,
+        expires_at: form.expires_at
+      };
+      if (resourceType === 'model') {
+        if (bulkMode && selectedModels.length > 0 && !policy) {
+          for (const m of selectedModels) {
+            const payload = { ...basePayload, resource_pattern: `model:${m}` };
+            const saved = await createQuotaPolicy(localStorage.token, payload);
+            dispatch('saved', saved);
+          }
+        } else {
+          const payload = {
+            ...basePayload,
+            resource_pattern: `model:${modelValue}`
+          };
+          let saved: QuotaPolicy;
+          if (policy) {
+            saved = await updateQuotaPolicy(localStorage.token, policy.id, payload);
+          } else {
+            saved = await createQuotaPolicy(localStorage.token, payload);
+          }
+          dispatch('saved', saved);
+        }
+      } else {
+        const value = resourceType === 'upload' ? uploadValue : imageValue;
+        const payload = {
+          ...basePayload,
+          resource_pattern: `${resourceType}:${value}`
+        };
+        let saved: QuotaPolicy;
+        if (policy) {
+          saved = await updateQuotaPolicy(localStorage.token, policy.id, payload);
+        } else {
+          saved = await createQuotaPolicy(localStorage.token, payload);
+        }
+        dispatch('saved', saved);
+      }
+      show = false;
+    } catch (e) {
+      toast.error(`${e}`);
+    }
+  }
+</script>
+
+<Modal bind:show>
+  <div class="p-4 space-y-4 text-gray-900 dark:text-gray-100">
+    <h2 class="text-lg font-semibold">{policy ? 'Edit Quota Policy' : 'Add Quota Policy'}</h2>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">User Email or ID</label>
+      <input
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={userInput}
+        placeholder="Enter user email or ID" />
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Plan</label>
+      <select
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.plan_id}>
+        <option value="">None</option>
+        {#each plans as p}
+          <option value={p.id}>{p.name} ({p.id})</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Resource Type</label>
+      <select
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={resourceType}>
+        <option value="model">model</option>
+        <option value="upload">upload</option>
+        <option value="image">image</option>
+      </select>
+    </div>
+
+    {#if resourceType === 'model'}
+      {#if !policy}
+        <div class="flex items-center gap-2">
+          <input
+            id="bulk"
+            type="checkbox"
+            class="h-4 w-4 text-blue-600 border-gray-300 rounded"
+            bind:checked={bulkMode} />
+          <label for="bulk" class="text-sm text-gray-700 dark:text-gray-300">Bulk add models</label>
+        </div>
+      {/if}
+
+      {#if bulkMode && !policy}
+        <div class="space-y-2">
+          <label class="block text-sm text-gray-700 dark:text-gray-300">Models</label>
+          <div class="space-y-2">
+            <div class="flex items-center gap-2 p-1 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800">
+              <Search class="size-4 text-gray-500" />
+              <input
+                class="flex-1 bg-transparent outline-none text-gray-900 dark:text-gray-100"
+                placeholder="Search models"
+                bind:value={modelSearch} />
+            </div>
+            <div class="max-h-40 overflow-y-auto border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800">
+              {#each filteredModelItems as item}
+                <label class="flex items-center gap-2 p-1 text-gray-900 dark:text-gray-100">
+                  <input type="checkbox" value={item.value} bind:group={selectedModels} />
+                  {item.label}
+                </label>
+              {/each}
+            </div>
+          </div>
+        </div>
+      {:else}
+        <div class="space-y-2">
+          <label class="block text-sm text-gray-700 dark:text-gray-300">Model</label>
+          <Selector bind:value={modelValue} items={modelItems} placeholder="Select a model" searchPlaceholder="Search models" />
+        </div>
+      {/if}
+    {:else if resourceType === 'upload'}
+      <div class="space-y-2">
+        <label class="block text-sm text-gray-700 dark:text-gray-300">Upload</label>
+        <input
+          class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+          bind:value={uploadValue}
+          placeholder="Enter upload pattern" />
+      </div>
+    {:else if resourceType === 'image'}
+      <div class="space-y-2">
+        <label class="block text-sm text-gray-700 dark:text-gray-300">Image</label>
+        <input
+          class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+          bind:value={imageValue}
+          placeholder="Enter image pattern" />
+      </div>
+    {/if}
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Limit</label>
+      <input
+        type="number"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.limit} />
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Window</label>
+      <select
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.window}>
+        <option value="3h">3h</option>
+        <option value="12h">12h</option>
+        <option value="day">day</option>
+        <option value="week">week</option>
+        <option value="month">month</option>
+      </select>
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Effective From</label>
+      <input
+        type="datetime-local"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        value={new Date(form.effective_from * 1000).toISOString().slice(0, 16)}
+        on:change={(e) => {
+          const value = (e.target as HTMLInputElement).value;
+          form.effective_from = value ? dayjs(value).unix() : form.effective_from;
+        }} />
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Expires At</label>
+      <input
+        type="datetime-local"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        value={form.expires_at ? new Date(form.expires_at * 1000).toISOString().slice(0, 16) : ''}
+        on:change={(e) => {
+          const value = (e.target as HTMLInputElement).value;
+          form.expires_at = value ? dayjs(value).unix() : undefined;
+        }} />
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+      <button
+        class="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+        on:click={() => (show = false)}>
+        Cancel
+      </button>
+      <button
+        class="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white"
+        on:click={save}>
+        Save
+      </button>
+    </div>
+  </div>
+</Modal>

--- a/src/lib/components/admin/QuotaPolicies/index.ts
+++ b/src/lib/components/admin/QuotaPolicies/index.ts
@@ -1,0 +1,2 @@
+export { default as QuotaPolicyList } from './QuotaPolicyList.svelte';
+export { default as QuotaPolicyModal } from './QuotaPolicyModal.svelte';


### PR DESCRIPTION
## Summary
- add resource type dropdown and search-enabled model selection in quota policy modal
- construct resource patterns for model, upload, and image types
- support bulk creation of model policies with searchable multi-select
- show user email/ID and plan name/ID in quota policy list and modal with light/dark mode styling
- handle quota policy timestamps with `dayjs` instead of a custom helper
- enable quick filtering in quota policy list via AG Grid's quick filter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npx eslint src/lib/components/admin/QuotaPolicies/QuotaPolicyList.svelte` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ef8d2e08333993a97fefd2f7b39