### PR TITLE
Add admin pages for plans and quota policies

### DIFF
--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -58,26 +58,40 @@
 							href="/admin">{$i18n.t('Users')}</a
 						>
 
-						<a
-							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/evaluations')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-							href="/admin/evaluations">{$i18n.t('Evaluations')}</a
-						>
+                                                <a
+                                                        class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/evaluations')
+                                                                ? ''
+                                                                : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                        href="/admin/evaluations">{$i18n.t('Evaluations')}</a
+                                                >
 
-						<a
-							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/functions')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-							href="/admin/functions">{$i18n.t('Functions')}</a
-						>
+                                                <a
+                                                        class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/functions')
+                                                                ? ''
+                                                                : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                        href="/admin/functions">{$i18n.t('Functions')}</a
+                                                >
 
-						<a
-							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/settings')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-							href="/admin/settings">{$i18n.t('Settings')}</a
-						>
+                                                <a
+                                                        class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/plans')
+                                                                ? ''
+                                                                : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                        href="/admin/plans">{$i18n.t('Plans')}</a
+                                                >
+
+                                                <a
+                                                        class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/quota-policies')
+                                                                ? ''
+                                                                : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                        href="/admin/quota-policies">{$i18n.t('Quota Policies')}</a
+                                                >
+
+                                                <a
+                                                        class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/settings')
+                                                                ? ''
+                                                                : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                        href="/admin/settings">{$i18n.t('Settings')}</a
+                                                >
 					</div>
 				</div>
 			</div>

--- a/src/routes/(app)/admin/plans/+page.svelte
+++ b/src/routes/(app)/admin/plans/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import PlanList from '$lib/components/admin/Plans/PlanList.svelte';
+</script>
+
+<PlanList />

--- a/src/routes/(app)/admin/quota-policies/+page.svelte
+++ b/src/routes/(app)/admin/quota-policies/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import QuotaPolicyList from '$lib/components/admin/QuotaPolicies/QuotaPolicyList.svelte';
+</script>
+
+<QuotaPolicyList />


### PR DESCRIPTION
## Summary
- Add Plans and Quota Policies admin pages
- Link Plans and Quota Policies in admin layout navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config; svelte-kit and pylint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32c7594188333b1a935411ab5322d