### PR TITLE
feat: separate media credits and transactional billing

### DIFF
--- a/backend/open_webui/models/billing.py
+++ b/backend/open_webui/models/billing.py
@@ -63,7 +63,11 @@ class UserCredit(Base):
     user_id = Column(String, primary_key=True)
     plan_id = Column(String, nullable=False)
     credit_balance = Column(BigInteger, nullable=False)
+    image_credit_balance = Column(BigInteger, nullable=False, default=0)
+    video_credit_balance = Column(BigInteger, nullable=False, default=0)
     monthly_quota = Column(BigInteger, nullable=False)
+    monthly_image_quota = Column(BigInteger, nullable=False, default=0)
+    monthly_video_quota = Column(BigInteger, nullable=False, default=0)
     current_period_end = Column(BigInteger, nullable=True)
     status = Column(SAEnum(StatusEnum, name="status_enum"), nullable=False, default=StatusEnum.active)
     updated_at = Column(BigInteger, nullable=False, default=lambda: int(time.time()))
@@ -92,6 +96,8 @@ class PaymentOrder(Base):
     plan_target = Column(Text, nullable=True)
     plan_id = Column(String, nullable=True)
     credits = Column(BigInteger, nullable=True)
+    image_credits = Column(BigInteger, nullable=True)
+    video_credits = Column(BigInteger, nullable=True)
     amount_mmk = Column(Numeric, nullable=False)
     provider = Column(String, nullable=False)
     status = Column(SAEnum(PaymentStatusEnum, name="payment_status_enum"), nullable=False,
@@ -155,7 +161,11 @@ class UserCreditsModel(BaseModel):
     user_id: str
     plan_id: str
     credit_balance: int
+    image_credit_balance: int
+    video_credit_balance: int
     monthly_quota: int
+    monthly_image_quota: int
+    monthly_video_quota: int
     current_period_end: Optional[int] = None
     status: StatusEnum
     updated_at: int
@@ -165,7 +175,11 @@ class UserCreditsForm(BaseModel):
     user_id: str
     plan_id: str
     credit_balance: int  # Add explicit credit_balance field
+    image_credit_balance: int = 0
+    video_credit_balance: int = 0
     monthly_quota: int
+    monthly_image_quota: int = 0
+    monthly_video_quota: int = 0
     current_period_end: Optional[int] = None
 
 
@@ -202,6 +216,8 @@ class PaymentOrderModel(BaseModel):
     plan_target: Optional[str] = None
     plan_id: Optional[str] = None
     credits: Optional[int] = None
+    image_credits: Optional[int] = None
+    video_credits: Optional[int] = None
     amount_mmk: float
     provider: str
     status: PaymentStatusEnum
@@ -224,6 +240,8 @@ class PaymentOrderForm(BaseModel):
     plan_target: Optional[str] = None
     plan_id: Optional[str] = None
     credits: Optional[int] = None
+    image_credits: Optional[int] = None
+    video_credits: Optional[int] = None
     amount_mmk: float
     provider: str
 
@@ -234,6 +252,8 @@ class AdminPaymentOrderForm(BaseModel):
     plan_target: Optional[str] = None
     plan_id: Optional[str] = None
     credits: Optional[int] = None
+    image_credits: Optional[int] = None
+    video_credits: Optional[int] = None
     amount_mmk: float
     provider: str
     notes: Optional[str] = None
@@ -287,7 +307,11 @@ class UserCreditsTable:
                 user_id=user_id,
                 plan_id=form.plan_id,
                 credit_balance=form.credit_balance,  # Use form.credit_balance instead of monthly_quota
+                image_credit_balance=form.image_credit_balance,
+                video_credit_balance=form.video_credit_balance,
                 monthly_quota=form.monthly_quota,
+                monthly_image_quota=form.monthly_image_quota,
+                monthly_video_quota=form.monthly_video_quota,
                 current_period_end=form.current_period_end,
                 status=StatusEnum.active,
                 updated_at=now_ts,
@@ -302,26 +326,32 @@ class UserCreditsTable:
             record = db.query(UserCredit).filter(UserCredit.user_id == user_id).first()
             return UserCreditsModel.model_validate(record) if record else None
 
-    def update_credits(self, user_id: str, delta: int) -> Optional[UserCreditsModel]:
+    def update_credits(self, user_id: str, delta: int, image_delta: int = 0, video_delta: int = 0) -> Optional[UserCreditsModel]:
         with get_db() as db:
             record = db.query(UserCredit).filter(UserCredit.user_id == user_id).first()
             if record is None:
                 return None
             record.credit_balance = record.credit_balance + delta
+            record.image_credit_balance = record.image_credit_balance + image_delta
+            record.video_credit_balance = record.video_credit_balance + video_delta
             record.updated_at = int(time.time())
             db.commit()
             db.refresh(record)
             return UserCreditsModel.model_validate(record)
 
-    def update_subscription(self, user_id: str, new_plan: str, monthly_quota: int, new_end: datetime.date, new_status: Optional[StatusEnum]=None) -> Optional[UserCreditsModel]:
+    def update_subscription(self, user_id: str, new_plan: str, monthly_quota: int, new_end: datetime.date, monthly_image_quota: int = 0, monthly_video_quota: int = 0, new_status: Optional[StatusEnum]=None) -> Optional[UserCreditsModel]:
         with get_db() as db:
             record = db.query(UserCredit).filter(UserCredit.user_id == user_id).first()
             if not record:
                 return None
             record.plan_id = new_plan
             record.monthly_quota = monthly_quota
+            record.monthly_image_quota = monthly_image_quota
+            record.monthly_video_quota = monthly_video_quota
             record.current_period_end = new_end
             record.credit_balance = record.credit_balance + monthly_quota
+            record.image_credit_balance = record.image_credit_balance + monthly_image_quota
+            record.video_credit_balance = record.video_credit_balance + monthly_video_quota
             record.status = new_status if new_status else StatusEnum.active
             record.updated_at = int(time.time())
             db.commit()
@@ -395,6 +425,8 @@ class PaymentOrdersTable:
                 plan_target=form.plan_target,
                 plan_id=form.plan_id,
                 credits=form.credits,
+                image_credits=form.image_credits,
+                video_credits=form.video_credits,
                 amount_mmk=form.amount_mmk,
                 provider=form.provider,
                 status=PaymentStatusEnum.pending,
@@ -423,6 +455,8 @@ class PaymentOrdersTable:
                 plan_target=form.plan_target,
                 plan_id=form.plan_id,
                 credits=form.credits,
+                image_credits=form.image_credits,
+                video_credits=form.video_credits,
                 amount_mmk=form.amount_mmk,
                 provider=form.provider,
                 status=PaymentStatusEnum.pending,
@@ -447,6 +481,8 @@ class PaymentOrdersTable:
                 record.plan_target = form.plan_target
                 record.plan_id = form.plan_id
                 record.credits = form.credits
+                record.image_credits = form.image_credits
+                record.video_credits = form.video_credits
                 record.amount_mmk = form.amount_mmk
                 record.provider = form.provider
                 record.notes = form.notes

--- a/backend/open_webui/models/plans.py
+++ b/backend/open_webui/models/plans.py
@@ -50,6 +50,8 @@ class PlanModel(BaseModel):
     description: Optional[str] = None
     price: float
     credits: int
+    image_credits: int
+    video_credits: int
     plan_type: PlanTypeEnum
     features: Optional[Dict[str, Any]] = None
     is_active: bool
@@ -62,6 +64,8 @@ class PlanForm(BaseModel):
     description: Optional[str] = None
     price: float
     credits: int
+    image_credits: int = 0
+    video_credits: int = 0
     plan_type: PlanTypeEnum
     features: Optional[Dict[str, Any]] = None
     is_active: bool = True

--- a/backend/open_webui/routers/billing.py
+++ b/backend/open_webui/routers/billing.py
@@ -37,6 +37,10 @@ class PlanPublicModel(PlanModel):
 class UserCreditsWithPlanModel(UserCreditsModel):
     credit_balance: int = Field(exclude=True)
     monthly_quota: int = Field(exclude=True)
+    image_credit_balance: int = Field(exclude=True)
+    video_credit_balance: int = Field(exclude=True)
+    monthly_image_quota: int = Field(exclude=True)
+    monthly_video_quota: int = Field(exclude=True)
     plan: Optional[PlanPublicModel] = None
 
 
@@ -221,6 +225,8 @@ async def create_order(
         plan_id: Annotated[Optional[str], Form()] = None,
         plan_target: Annotated[Optional[str], Form()] = None,
         credits: Annotated[Optional[int], Form()] = None,
+        image_credits: Annotated[Optional[int], Form()] = None,
+        video_credits: Annotated[Optional[int], Form()] = None,
         discount_code: Annotated[Optional[str], Form()] = None,
         screenshot: UploadFile = File(...),
         user=Depends(get_verified_user),
@@ -246,7 +252,9 @@ async def create_order(
         provider=provider,
         plan_id=plan_id,
         plan_target=plan_target,
-        credits=credits
+        credits=credits,
+        image_credits=image_credits,
+        video_credits=video_credits
     )
 
     # Check if discount code was provided and is valid
@@ -397,8 +405,10 @@ async def confirm_order(
             detail=ERROR_MESSAGES.DEFAULT()
         )
 
-    # 2. Allocate credits based on the order (if credits > 0)
-    if order.credits and order.credits > 0:
+    # 2. Allocate credits based on the order (if any credits > 0)
+    if (order.credits and order.credits > 0) or \
+       (order.image_credits and order.image_credits > 0) or \
+       (order.video_credits and order.video_credits > 0):
         try:
             # Check if user already has a credit wallet
             existing_credits = UserCredits.get_user_credits(order.user_id)
@@ -407,19 +417,34 @@ async def confirm_order(
                 # User has existing credits - add to their balance
                 updated_credits = None
                 if order.type == OrderTypeEnum.plan_payment or order.type == OrderTypeEnum.manual:
-                    updated_credits = UserCredits.update_subscription(user_id=order.user_id, new_plan=order.plan_id,
-                                                                      monthly_quota=order.credits,
-                                                                      new_end=order.period_end)
+                    updated_credits = UserCredits.update_subscription(
+                        user_id=order.user_id,
+                        new_plan=order.plan_id,
+                        monthly_quota=order.credits or 0,
+                        monthly_image_quota=order.image_credits or 0,
+                        monthly_video_quota=order.video_credits or 0,
+                        new_end=order.period_end,
+                    )
                 elif order.type == OrderTypeEnum.credit:
-                    updated_credits = UserCredits.update_credits(order.user_id, order.credits)
+                    updated_credits = UserCredits.update_credits(
+                        order.user_id,
+                        order.credits or 0,
+                        image_delta=order.image_credits or 0,
+                        video_delta=order.video_credits or 0,
+                    )
                 elif order.type == OrderTypeEnum.upgrade:
-                    updated_credits = UserCredits.update_subscription(user_id=order.user_id, new_plan=order.plan_target,
-                                                                      monthly_quota=order.credits,
-                                                                      new_end=order.period_end)
+                    updated_credits = UserCredits.update_subscription(
+                        user_id=order.user_id,
+                        new_plan=order.plan_target,
+                        monthly_quota=order.credits or 0,
+                        monthly_image_quota=order.image_credits or 0,
+                        monthly_video_quota=order.video_credits or 0,
+                        new_end=order.period_end,
+                    )
 
                 if updated_credits:
                     log.info(
-                        f"Added {order.credits} credits to existing wallet for user {order.user_id}. New balance: {updated_credits.credit_balance}")
+                        f"Added credits to existing wallet for user {order.user_id}. New balances: text={updated_credits.credit_balance}, image={updated_credits.image_credit_balance}, video={updated_credits.video_credit_balance}")
                     try:
                         from open_webui.models.groups import Groups
                         group_name = str(order.plan_id).capitalize()
@@ -441,27 +466,54 @@ async def confirm_order(
                 credit_form = UserCreditsForm(
                     user_id=order.user_id,
                     plan_id=order.plan_id,
-                    credit_balance=order.credits,
-                    monthly_quota=order.credits,
-                    current_period_end=order.period_end
+                    credit_balance=order.credits or 0,
+                    image_credit_balance=order.image_credits or 0,
+                    video_credit_balance=order.video_credits or 0,
+                    monthly_quota=order.credits or 0,
+                    monthly_image_quota=order.image_credits or 0,
+                    monthly_video_quota=order.video_credits or 0,
+                    current_period_end=order.period_end,
                 )
                 new_credits = UserCredits.insert_new_user_credits(order.user_id, credit_form)
                 if new_credits:
-                    log.info(f"Created new credit wallet with {order.credits} credits for user {order.user_id}")
+                    log.info(f"Created new credit wallet for user {order.user_id}")
                 else:
                     log.error(f"Failed to create credit wallet for user {order.user_id}")
 
             # Record the credit allocation transaction
             try:
-                CreditTransactions.insert_transaction(
-                    order.user_id,
-                    CreditTransactionForm(
-                        tx_id=f"payment_{order.order_id}",
-                        delta=order.credits,  # Positive delta for credit addition
-                        usd_spend=0.0,  # This is a purchase, not usage
-                        model_name="plan_purchase"
+                if order.credits:
+                    CreditTransactions.insert_transaction(
+                        order.user_id,
+                        CreditTransactionForm(
+                            tx_id=f"payment_{order.order_id}_text",
+                            delta=order.credits,
+                            usd_spend=0.0,
+                            model_name="plan_purchase"
+                        )
                     )
-                )
+                if order.image_credits:
+                    CreditTransactions.insert_transaction(
+                        order.user_id,
+                        CreditTransactionForm(
+                            tx_id=f"payment_{order.order_id}_image",
+                            delta=order.image_credits,
+                            usd_spend=0.0,
+                            model_name="plan_purchase",
+                            resource_type="image"
+                        )
+                    )
+                if order.video_credits:
+                    CreditTransactions.insert_transaction(
+                        order.user_id,
+                        CreditTransactionForm(
+                            tx_id=f"payment_{order.order_id}_video",
+                            delta=order.video_credits,
+                            usd_spend=0.0,
+                            model_name="plan_purchase",
+                            resource_type="video"
+                        )
+                    )
                 log.info(f"Recorded credit allocation transaction for order {order_id}")
             except Exception as tx_error:
                 log.error(f"Failed to record credit transaction for order {order_id}: {tx_error}")
@@ -472,7 +524,7 @@ async def confirm_order(
             # Log error but don't fail the payment confirmation
             # Consider adding a flag to track credit allocation failures
     else:
-        log.info(f"No credits to allocate for order {order_id} (credits: {order.credits})")
+        log.info(f"No credits to allocate for order {order_id} (credits: {order.credits}, image_credits: {order.image_credits}, video_credits: {order.video_credits})")
 
     # 3. Track subscription completion analytics
     log.info(f"Subscription completed for user {order.user_id}, order {order_id}, plan {order.plan_id}, credits {order.credits}")

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -24,6 +24,7 @@ from open_webui.utils.images.input_builders import build_model_input
 from open_webui.utils.images.image_tasks import enqueue_prediction_job
 from open_webui.models.users import Users
 from open_webui.models.billing import CreditTransactions, CreditTransactionForm, UserCredits
+from open_webui.utils.billing import requires_image_credits
 from open_webui.model_configs import MODEL_CONFIGS, AspectRatio, Resolution, StyleType, Background, OutputFormat, \
     ContentModeration
 from open_webui.telegram_bot import send_telegram_message
@@ -469,6 +470,7 @@ def load_url_image_data(url, headers=None):
 
 
 @router.post("/generations")
+@requires_image_credits
 async def image_generations(
         request: Request,
         form_data: GenerateImageForm,

--- a/backend/open_webui/utils/billing.py
+++ b/backend/open_webui/utils/billing.py
@@ -11,11 +11,20 @@ from fastapi import Request, HTTPException, status, Response
 from open_webui.utils.pricing import estimate_cost, affordable, calculate_cost
 from open_webui.utils.error_handler import sanitize_error
 from open_webui.models.billing import StatusEnum
-from open_webui.models.billing import UserCredits, CreditTransactions, CreditTransactionForm
+from open_webui.models.billing import (
+    UserCredits,
+    CreditTransactions,
+    CreditTransactionForm,
+    UserCredit,
+    CreditTransaction,
+)
+from open_webui.internal.db import get_db
+import time
 from open_webui.utils.auth import get_current_user, get_http_authorization_cred
 from open_webui.models.models import Models
 import logging
 import json
+import uuid
 from typing import Optional, Dict, Any, List
 
 log = logging.getLogger(__name__)
@@ -46,6 +55,30 @@ async def check_balance(user_id: str, min_credits: int = 1) -> Optional[int]:
             detail="Insufficient credits",
         )
     return my_credits.credit_balance
+
+
+async def check_image_balance(user_id: str, min_credits: int = 1) -> Optional[int]:
+    my_credits = UserCredits.get_user_credits(user_id)
+
+    if my_credits.status != StatusEnum.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Subscription has ended. Please contact support for further assistance.",
+        )
+
+    now = datetime.now()
+    if my_credits.current_period_end and now > datetime.fromtimestamp(my_credits.current_period_end):
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail="Subscription period has ended",
+        )
+
+    if not my_credits or my_credits.image_credit_balance < min_credits:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail="Insufficient credits",
+        )
+    return my_credits.image_credit_balance
 
 
 def _parse_response_body(response: Response) -> dict | None:
@@ -125,6 +158,80 @@ async def process_billing(
         )
 
 DEFAULT_FALLBACK_MODEL = 'gpt-4.1-nano'  # Default fallback model
+
+def requires_image_credits(func):
+    """Decorator to bill image generation requests based on a simple price map."""
+
+    price_map = {
+        "gemini-2.5-flash-image": 30,  # 30 credits per image
+    }
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        request: Request = kwargs.get("request") or (args[0] if args else None)
+        form_data = kwargs.get("form_data") or (args[1] if len(args) > 1 else None)
+        user = kwargs.get("user")
+
+        if not user or request is None or form_data is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Request, form data, and user context required",
+            )
+
+        # Determine which model is being used
+        engine = request.app.state.config.IMAGE_GENERATION_ENGINE
+        model_name = request.app.state.config.IMAGE_GENERATION_MODEL
+        if engine == "openai":
+            model_name = model_name or "dall-e-2"
+        elif engine == "gemini":
+            model_name = model_name or "imagen-3.0-generate-002"
+
+        n_images = getattr(form_data, "n", 1) or 1
+        credits_per_image = price_map.get(model_name, 1)
+        total_cost = credits_per_image * n_images
+
+        # Ensure user has enough image credits
+        await check_image_balance(user.id, total_cost)
+
+        # Execute the original function
+        result = await func(*args, **kwargs)
+
+        try:
+            with get_db() as db:
+                db.begin()
+                record = (
+                    db.query(UserCredit)
+                    .filter(UserCredit.user_id == user.id)
+                    .with_for_update()
+                    .first()
+                )
+                if not record or record.image_credit_balance < total_cost:
+                    db.rollback()
+                    raise HTTPException(
+                        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                        detail="Insufficient credits",
+                    )
+                record.image_credit_balance -= total_cost
+                record.updated_at = int(time.time())
+                tx = CreditTransaction(
+                    tx_id=str(uuid.uuid4()),
+                    user_id=user.id,
+                    delta=-total_cost,
+                    usd_spend=0.0,
+                    model_name=model_name,
+                    resource_type="image_generation",
+                    meta={"n": n_images},
+                    created_at=int(time.time()),
+                )
+                db.add(tx)
+                db.commit()
+        except Exception as e:
+            log.error(f"Error recording image credit transaction: {e}")
+            raise
+
+        return result
+
+    return wrapper
 
 def requires_credits(min_credits: int = 1):
     def decorator(func):

--- a/src/lib/apis/billing/index.ts
+++ b/src/lib/apis/billing/index.ts
@@ -183,12 +183,16 @@ export const declinePaymentOrder = async (token: string, orderId: string) => {
 
 // Admin: Create credit wallet for a user
 export const createUserCredits = async (
-	token: string,
-	userId: string,
-	planId: string,
-	creditBalance: number,
-	monthlyQuota: number,
-	currentPeriodEnd?: number
+        token: string,
+        userId: string,
+        planId: string,
+        creditBalance: number,
+        imageCreditBalance: number,
+        videoCreditBalance: number,
+        monthlyQuota: number,
+        monthlyImageQuota: number,
+        monthlyVideoQuota: number,
+        currentPeriodEnd?: number
 ) => {
 	const response = await fetch(`${WEBUI_API_BASE_URL}/billing/credits`, {
 		method: 'POST',
@@ -197,13 +201,17 @@ export const createUserCredits = async (
 			Authorization: `Bearer ${token}`
 		},
 		body: JSON.stringify({
-			user_id: userId,
-			plan_id: planId,
-			credit_balance: creditBalance,
-			monthly_quota: monthlyQuota,
-			current_period_end: currentPeriodEnd
-		})
-	});
+                        user_id: userId,
+                        plan_id: planId,
+                        credit_balance: creditBalance,
+                        image_credit_balance: imageCreditBalance,
+                        video_credit_balance: videoCreditBalance,
+                        monthly_quota: monthlyQuota,
+                        monthly_image_quota: monthlyImageQuota,
+                        monthly_video_quota: monthlyVideoQuota,
+                        current_period_end: currentPeriodEnd
+                })
+        });
 
 	if (!response.ok) {
 		throw new Error('Failed to create user credits');

--- a/src/lib/components/admin/Plans/PlanList.svelte
+++ b/src/lib/components/admin/Plans/PlanList.svelte
@@ -82,6 +82,8 @@
     { headerName: 'Type', field: 'plan_type', sortable: true },
     { headerName: 'Price', field: 'price', sortable: true },
     { headerName: 'Credits', field: 'credits', sortable: true },
+    { headerName: 'Image Credits', field: 'image_credits', sortable: true },
+    { headerName: 'Video Credits', field: 'video_credits', sortable: true },
     { headerName: 'Active', field: 'is_active', sortable: true },
     { headerName: 'Actions', cellRenderer: actionCellRenderer, sortable: false, filter: false }
   ];

--- a/src/lib/components/admin/Plans/PlanModal.svelte
+++ b/src/lib/components/admin/Plans/PlanModal.svelte
@@ -16,6 +16,8 @@
     description: '',
     price: 0,
     credits: 0,
+    image_credits: 0,
+    video_credits: 0,
     plan_type: 'subscription' as PlanType,
     features: {},
     is_active: true,
@@ -24,15 +26,31 @@
   };
 
   let form: Plan = { ...defaultForm };
+  let featuresText = JSON.stringify(form.features, null, 2);
+  let featuresError = '';
 
   $: if (plan) {
     form = { ...plan };
+    featuresText = JSON.stringify(form.features ?? {}, null, 2);
   } else {
     form = { ...defaultForm };
+    featuresText = JSON.stringify(form.features ?? {}, null, 2);
   }
 
   async function save() {
     try {
+      let parsedFeatures = {};
+      if (featuresText.trim()) {
+        try {
+          parsedFeatures = JSON.parse(featuresText);
+          form.features = parsedFeatures;
+          featuresError = '';
+        } catch (e) {
+          featuresError = 'Invalid JSON';
+          throw e;
+        }
+      }
+
       let saved: Plan;
       if (plan) {
         saved = await updatePlan(localStorage.token, plan.id, {
@@ -40,8 +58,10 @@
           description: form.description,
           price: form.price,
           credits: form.credits,
+          image_credits: form.image_credits,
+          video_credits: form.video_credits,
           plan_type: form.plan_type,
-          features: form.features,
+          features: parsedFeatures,
           is_active: form.is_active
         });
       } else {
@@ -50,8 +70,10 @@
           description: form.description,
           price: form.price,
           credits: form.credits,
+          image_credits: form.image_credits,
+          video_credits: form.video_credits,
           plan_type: form.plan_type,
-          features: form.features,
+          features: parsedFeatures,
           is_active: form.is_active
         });
       }
@@ -95,6 +117,33 @@
         class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
         bind:value={form.credits}
       />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Image Credits</label>
+      <input
+        type="number"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.image_credits}
+      />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Video Credits</label>
+      <input
+        type="number"
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        bind:value={form.video_credits}
+      />
+    </div>
+    <div class="space-y-2">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">Features (JSON)</label>
+      <textarea
+        class="w-full p-2 border border-gray-300 dark:border-gray-700 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-mono"
+        rows="4"
+        bind:value={featuresText}
+      ></textarea>
+      {#if featuresError}
+        <p class="text-sm text-red-500">{featuresError}</p>
+      {/if}
     </div>
     <div class="space-y-2">
       <label class="block text-sm text-gray-700 dark:text-gray-300">Plan Type</label>

--- a/src/lib/components/admin/Settings/Orders.svelte
+++ b/src/lib/components/admin/Settings/Orders.svelte
@@ -15,19 +15,21 @@
 	const i18n: any = getContext('i18n');
 
 	// Type definitions
-	interface PaymentOrder {
-		order_id: string;
-		user_id: string;
-		user_name?: string;
-		user_email?: string;
-		amount_mmk: number;
-		credits?: number;
-		status: string;
-		created_at: number;
-		screenshot_path?: string;
-		plan_id?: string;
-		provider?: string;
-	}
+        interface PaymentOrder {
+                order_id: string;
+                user_id: string;
+                user_name?: string;
+                user_email?: string;
+                amount_mmk: number;
+                credits?: number;
+                image_credits?: number;
+                video_credits?: number;
+                status: string;
+                created_at: number;
+                screenshot_path?: string;
+                plan_id?: string;
+                provider?: string;
+        }
 
 	// Data and state
 	let orders: PaymentOrder[] = [];

--- a/src/lib/components/admin/Users/PaymentOrder/PaymentOrderModal.svelte
+++ b/src/lib/components/admin/Users/PaymentOrder/PaymentOrderModal.svelte
@@ -11,33 +11,39 @@
 	let users = [];
 	let selectedUserId = '';
 	let orderType = 'manual';
-	let planId = 'free';
-	let credits = 0;
-	let amount = 0;
-	let provider = 'manual';
-	let notes = '';
+        let planId = 'free';
+        let credits = 0;
+        let imageCredits = 0;
+        let videoCredits = 0;
+        let amount = 0;
+        let provider = 'manual';
+        let notes = '';
 
 	const dispatch = createEventDispatcher();
 
 	const initializeForm = (order) => {
 		if (order) {
-			selectedUserId = order.user_id;
-			orderType = order.type;
-			planId = order.plan_id;
-			credits = order.credits;
-			amount = order.amount_mmk;
-			provider = order.provider;
-			notes = order.notes;
-		} else {
-			selectedUserId = '';
-			orderType = 'manual';
-			planId = 'free';
-			credits = 0;
-			amount = 0;
-			provider = 'manual';
-			notes = '';
-		}
-	};
+                        selectedUserId = order.user_id;
+                        orderType = order.type;
+                        planId = order.plan_id;
+                        credits = order.credits;
+                        imageCredits = order.image_credits;
+                        videoCredits = order.video_credits;
+                        amount = order.amount_mmk;
+                        provider = order.provider;
+                        notes = order.notes;
+                } else {
+                        selectedUserId = '';
+                        orderType = 'manual';
+                        planId = 'free';
+                        credits = 0;
+                        imageCredits = 0;
+                        videoCredits = 0;
+                        amount = 0;
+                        provider = 'manual';
+                        notes = '';
+                }
+        };
 
 	$: initializeForm(order);
 
@@ -53,27 +59,31 @@
 	const handleSubmit = async () => {
 		try {
 			if (order) {
-				await updatePaymentOrder(localStorage.token, order.order_id, {
-					user_id: selectedUserId,
-					type: orderType,
-					plan_id: planId,
-					credits: credits,
-					amount_mmk: amount,
-					provider: provider,
-					notes: notes
-				});
-				toast.success('Payment order updated successfully');
-			} else {
-				await createManualPaymentOrder(localStorage.token, {
-					user_id: selectedUserId,
-					type: orderType,
-					plan_id: planId,
-					credits: credits,
-					amount_mmk: amount,
-					provider: provider,
-					notes: notes
-				});
-				toast.success('Payment order created successfully');
+                                await updatePaymentOrder(localStorage.token, order.order_id, {
+                                        user_id: selectedUserId,
+                                        type: orderType,
+                                        plan_id: planId,
+                                        credits: credits,
+                                        image_credits: imageCredits,
+                                        video_credits: videoCredits,
+                                        amount_mmk: amount,
+                                        provider: provider,
+                                        notes: notes
+                                });
+                                toast.success('Payment order updated successfully');
+                        } else {
+                                await createManualPaymentOrder(localStorage.token, {
+                                        user_id: selectedUserId,
+                                        type: orderType,
+                                        plan_id: planId,
+                                        credits: credits,
+                                        image_credits: imageCredits,
+                                        video_credits: videoCredits,
+                                        amount_mmk: amount,
+                                        provider: provider,
+                                        notes: notes
+                                });
+                                toast.success('Payment order created successfully');
 			}
 			dispatch('save');
 			close();
@@ -162,17 +172,41 @@
 				</select>
 			</div>
 
-			<div>
-				<label for="credits" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-					Credits
-				</label>
-				<input
-					type="number"
-					id="credits"
-					bind:value={credits}
-					class="mt-1 block w-full py-2 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-				/>
-			</div>
+                        <div>
+                                <label for="credits" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Credits
+                                </label>
+                                <input
+                                        type="number"
+                                        id="credits"
+                                        bind:value={credits}
+                                        class="mt-1 block w-full py-2 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                />
+                        </div>
+
+                        <div>
+                                <label for="imageCredits" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Image Credits
+                                </label>
+                                <input
+                                        type="number"
+                                        id="imageCredits"
+                                        bind:value={imageCredits}
+                                        class="mt-1 block w-full py-2 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                />
+                        </div>
+
+                        <div>
+                                <label for="videoCredits" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Video Credits
+                                </label>
+                                <input
+                                        type="number"
+                                        id="videoCredits"
+                                        bind:value={videoCredits}
+                                        class="mt-1 block w-full py-2 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                />
+                        </div>
 
 			<div>
 				<label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/src/lib/stores/credits.ts
+++ b/src/lib/stores/credits.ts
@@ -2,14 +2,18 @@ import { writable, derived } from 'svelte/store';
 import { getUserCredits } from '$lib/apis/billing';
 
 export interface UserCredits {
-	user_id: string;
-	plan_id: string;
-	credit_balance: number;
-	monthly_quota: number;
-	current_period_end?: number;
-	status: 'active' | 'grace' | 'expired';
-	updated_at: number;
-	plan?: {
+        user_id: string;
+        plan_id: string;
+        credit_balance: number;
+        image_credit_balance: number;
+        video_credit_balance: number;
+        monthly_quota: number;
+        monthly_image_quota: number;
+        monthly_video_quota: number;
+        current_period_end?: number;
+        status: 'active' | 'grace' | 'expired';
+        updated_at: number;
+        plan?: {
 		id: string;
 		name: string;
 		plan_type: string;
@@ -39,8 +43,8 @@ const TOAST_COOLDOWN = 60 * 60 * 1000; // 1 hour
 
 // Derived stores for computed values
 export const creditPercentage = derived(userCredits, ($credits) => {
-	if (!$credits || $credits.monthly_quota <= 0) return 0;
-	return Math.max(0, Math.min(100, ($credits.credit_balance / $credits.monthly_quota) * 100));
+        if (!$credits || $credits.monthly_quota <= 0) return 0;
+        return Math.max(0, Math.min(100, ($credits.credit_balance / $credits.monthly_quota) * 100));
 });
 
 export const isCreditsLow = derived(creditPercentage, ($percentage) => $percentage < 20);

--- a/src/lib/types/plans.ts
+++ b/src/lib/types/plans.ts
@@ -6,6 +6,8 @@ export interface Plan {
     description?: string;
     price: number;
     credits: number;
+    image_credits: number;
+    video_credits: number;
     plan_type: PlanType;
     features?: Record<string, unknown>;
     is_active: boolean;


### PR DESCRIPTION
## Summary
- add image_credit_balance and video_credit_balance to user credits and payment orders
- debit image requests via transactional `requires_image_credits` decorator
- expose media credit fields in billing APIs and admin UI
- track monthly image and video quotas and allocate them on order confirmation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util'; No module named 'moto'; No module named 'open_webui')*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33580ad388333a7370cf69fe8743a