### PR TITLE
fix focus trap preventing editing in admin modals

### DIFF
--- a/src/lib/components/admin/Plans/PlanModal.svelte
+++ b/src/lib/components/admin/Plans/PlanModal.svelte
@@ -31,10 +31,10 @@
 
   $: if (plan) {
     form = { ...plan };
-    featuresText = JSON.stringify(form.features ?? {}, null, 2);
+    featuresText = JSON.stringify(plan.features ?? {}, null, 2);
   } else {
     form = { ...defaultForm };
-    featuresText = JSON.stringify(form.features ?? {}, null, 2);
+    featuresText = JSON.stringify(defaultForm.features ?? {}, null, 2);
   }
 
   async function save() {

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -56,18 +56,21 @@ const sizeToWidth = (size: string): string => {
 		mounted = true;
 	});
 
-	$: if (show && modalElement) {
-		document.body.appendChild(modalElement);
-		focusTrap = FocusTrap.createFocusTrap(modalElement);
-		focusTrap.activate();
-		window.addEventListener('keydown', handleKeyDown);
-		document.body.style.overflow = 'hidden';
-	} else if (modalElement) {
-		focusTrap.deactivate();
-		window.removeEventListener('keydown', handleKeyDown);
-		document.body.removeChild(modalElement);
-		document.body.style.overflow = 'unset';
-	}
+        $: if (show && modalElement) {
+                document.body.appendChild(modalElement);
+                focusTrap = FocusTrap.createFocusTrap(modalElement, {
+                        allowOutsideClick: true,
+                        fallbackFocus: modalElement
+                });
+                focusTrap.activate();
+                window.addEventListener('keydown', handleKeyDown);
+                document.body.style.overflow = 'hidden';
+        } else if (modalElement) {
+                focusTrap.deactivate();
+                window.removeEventListener('keydown', handleKeyDown);
+                document.body.removeChild(modalElement);
+                document.body.style.overflow = 'unset';
+        }
 
 	onDestroy(() => {
 		show = false;


### PR DESCRIPTION
## Summary
- allow outside clicks and set fallback focus in Modal focus trap so inputs can be edited

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename 'node_modules/katex')*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b390ffd5788333800fef060150031e