### PR TITLE
Add starlette-admin to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -144,3 +144,4 @@ opentelemetry-instrumentation-requests==0.53b1
 opentelemetry-instrumentation-logging==0.53b1
 opentelemetry-instrumentation-httpx==0.53b1
 opentelemetry-instrumentation-aiohttp-client==0.53b1
+starlette-admin==0.11.0


### PR DESCRIPTION
## Summary
- include starlette-admin as a pinned backend dependency

## Testing
- `pip install --dry-run --no-deps -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement rq)*
- `pip install --dry-run --no-deps starlette-admin==0.11.0` *(fails: Could not find a version that satisfies the requirement starlette-admin==0.11.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc950097248333bb96c259594496e4